### PR TITLE
AggregatorInterpreter fixes

### DIFF
--- a/lib/Interpreter/AggregatorInterpreter.php
+++ b/lib/Interpreter/AggregatorInterpreter.php
@@ -37,7 +37,7 @@ use Volkszaehler\Util;
  * @author Steffen Vogel <info@steffenvogel.de>
  * @package default
  */
-class AggregatorInterpreter {
+class AggregatorInterpreter extends Interpreter {
 	/**
 	 * @var array of Interpreter
 	 */


### PR DESCRIPTION
this fixes "Call to a member function getMax() on a non-object in
/var/www/vz/lib/Interpreter/AggregatorInterpreter.php on line 110" errors.

Das passiert teilweise bei mir, wenn ich eine komplette Gruppe abwähle.

Außerdem sollte AggregatorInterpreter doch auch von Interpreter abgeleitet sein, oder? Ansonsten fehlen Methoden wie "getFrom()".
