### PR TITLE
siehe VZ-DEV mailing Liste iOS frontend

### DIFF
--- a/htdocs/frontend/index.html
+++ b/htdocs/frontend/index.html
@@ -8,6 +8,7 @@
 	
 	<link rel="shortcut icon" type="image/x-icon" href="../favicon.ico" />
 	<link rel="apple-touch-icon-precomposed" href="../favicon.ico" />
+	<!-- to support android versions newer than 2.3 -->
 	<link rel="apple-touch-icon" href="../favicon.ico" />
 	<meta name="apple-mobile-web-app-capable" content="yes" />
 	<meta name="apple-mobile-web-app-status-bar-style" content="black" />


### PR DESCRIPTION
Hi,

ich habe einmal meine Version hier[1] auf github gepackt. Die Viewports braucht man eigentlich nicht, da sich die Webseite von alleine gut auf iPhone 4 skaliert.

Kurz zur Erklärung:
-Icon precomposed: kein gloss effekt (Vergleich in [2]
-WebCapable: App verhält sich dann wie eine installierte App
-NavigationBar color [3]
-Titel auf iOS kürzer, damit beim klick auf "Add to HomeScreen" keine Einstellungen verändert werden müssen und der Titel für den HomeScreen nicht zu lang ist[5]

Falls euch davon etwas gefällt, nehmt es gerne auf, ich sende einen pullrequest.

Viele Grüße
Christian

[1] https://github.com/ctvoigt/volkszaehler.org/blob/master/htdocs/frontend/index.html
[2] https://www.dropbox.com/s/ik5kz44hamuvl93/icon.png
[3] https://www.dropbox.com/s/f55quhdv2nvxgje/browser_webcapable.png 
[4] https://www.dropbox.com/s/w9simnyjiyi3625/title.png 
[5] https://www.dropbox.com/s/w9simnyjiyi3625/title.png
