### PR TITLE
Fixed negative number formatting

### DIFF
--- a/htdocs/frontend/javascripts/wui.js
+++ b/htdocs/frontend/javascripts/wui.js
@@ -539,7 +539,7 @@ vz.wui.formatNumber = function(number, prefix) {
 	var siPrefixes = ['k', 'M', 'G', 'T'];
 	var siIndex = 0;
 	
-	while (prefix && number > 1000 && siIndex < siPrefixes.length-1) {
+	while (prefix && Math.abs(number) > 1000 && siIndex < siPrefixes.length-1) {
 		number /= 1000;
 		siIndex++;
 	}


### PR DESCRIPTION
Using volkszaehler for energy generation meters, e.g. solar power, power production is often shown as negative values. For negative values, `wui.js` is not able to round Wh to kWh and similiar.

This patch fixes the issue.
