### PR TITLE
Fix broken JSON-Syntax

### DIFF
--- a/lib/Definition/EntityDefinition.json
+++ b/lib/Definition/EntityDefinition.json
@@ -281,7 +281,7 @@
 	{
 		"name"			: "valve",
 		"optional"		: ["tolerance", "local"],
-		//"icon"			: "rain.png",
+		"icon"			: "",
 		"unit"			: "%",
 		"interpreter"		: "Volkszaehler\\Interpreter\\SensorInterpreter",
 		"model"			: "Volkszaehler\\Model\\Channel",


### PR DESCRIPTION
JSON does not allow comments inside files. Currently the file can not be parsed by PHPs json_decode due to the header and a inline comment. This commit removes the inline comment so the file can at least be processed after stripping it's headers.
