### PR TITLE
Fix error with long aggregates (week/month)

### DIFF
--- a/lib/Interpreter/Interpreter.php
+++ b/lib/Interpreter/Interpreter.php
@@ -179,7 +179,7 @@ abstract class Interpreter {
 					   'FROM ('.
 					   '	SELECT timestamp, value, @row:=@row+1 AS row '.
 					   ' 	FROM data WHERE channel_id=?' . $sqlTimeFilter . 
-					   ') AS aggregate '.
+					   'ORDER BY timestamp ) AS aggregate '.
 					   'GROUP BY row DIV ' . $packageSize .' '.
 					   'ORDER BY timestamp ASC';
 			}


### PR DESCRIPTION
Hi,

I think I found at least one problem with large zoom out, if the data is not stored in timestamp order (by vzcompress or manual load). Please verify the change.
