### PR TITLE
fix middleware code to allow using it without going through Router class / HTTP

### DIFF
--- a/lib/Controller/Controller.php
+++ b/lib/Controller/Controller.php
@@ -41,7 +41,7 @@ abstract class Controller {
 	 * @param View $view
 	 * @param EntityManager $em
 	 */
-	public function __construct(View\View $view, \Doctrine\ORM\EntityManager $em) {
+	public function __construct(/*View\View*/ $view, \Doctrine\ORM\EntityManager $em) {
 		$this->view = $view;
 		$this->em = $em;
 	}
@@ -55,7 +55,7 @@ abstract class Controller {
 		if (!method_exists($this, $op)) {
 			throw new \Exception('Invalid context operation: \'' . $op . '\'');
 		}
-		
+
 		switch(count($arg)) { // improved performence
 			case 0: return $this->{$op}();
 			case 1: return $this->{$op}($arg[0]);

--- a/lib/Interpreter/Interpreter.php
+++ b/lib/Interpreter/Interpreter.php
@@ -278,19 +278,22 @@ abstract class Interpreter {
 	 * @link http://de3.php.net/manual/en/datetime.formats.php
 	 * @todo add millisecond resolution
 	 *
-	 * @param string $ts string to parse
+	 * @param mixed $ts int or string to parse
 	 * @param float $now in ms since 1970
 	 * @return float
 	 */
-	protected static function parseDateTimeString($string) {
-		if (ctype_digit($string)) { // handling as ms timestamp
-			return (float) $string;
+	protected static function parseDateTimeString($val) {
+		if (ctype_digit($val)) { // handling as ms timestamp
+			return (float) $val;
 		}
-		elseif ($ts = strtotime($string)) {
+		elseif (is_int($val)) { // allow numeric parameters
+			return $val;
+		}
+		elseif ($ts = strtotime($val)) {
 			return $ts * 1000;
 		}
 		else {
-			throw new \Exception('Invalid time format: \'' . $string . '\'');
+			throw new \Exception('Invalid time format: \'' . $val . '\'');
 		}
 	}
 


### PR DESCRIPTION
Aktuell ist es defacto unmöglich, die VZ Klassen in eigenen Skripten einzusetzen. 

Dieser Patch ändert daher zwei Stellen:
- erlaubt Anlegen von (Entity) Controllern ohne View
- erlaubt Anlegen von Interpretern mit numerischen Parametern (bisher war String notwendig was wenig intuitiv ist)

Damit werden z.B. die folgenden Skriptzeilen möglich:

```
$em = Volkszaehler\Router::createEntityManager();

$view = null;
$ec = new Controller\EntityController($view, $em);
$entity = $ec->get($uuid);

$class = $entity->getDefinition()->getInterpreter();
$interpreter = new $class($entity, $em, 1, 1);

$tuples = $interpreter->processData(function($tuple) { return $tuple; });
```
