### PR TITLE
Fix middleware code to allow using it without going through Router class / HTTP

### DIFF
--- a/lib/Controller/Controller.php
+++ b/lib/Controller/Controller.php
@@ -41,7 +41,7 @@ abstract class Controller {
 	 * @param View $view
 	 * @param EntityManager $em
 	 */
-	public function __construct(View\View $view, \Doctrine\ORM\EntityManager $em) {
+	public function __construct(/*View\View*/ $view, \Doctrine\ORM\EntityManager $em) {
 		$this->view = $view;
 		$this->em = $em;
 	}
@@ -55,7 +55,7 @@ abstract class Controller {
 		if (!method_exists($this, $op)) {
 			throw new \Exception('Invalid context operation: \'' . $op . '\'');
 		}
-		
+
 		switch(count($arg)) { // improved performence
 			case 0: return $this->{$op}();
 			case 1: return $this->{$op}($arg[0]);

--- a/lib/Interpreter/Interpreter.php
+++ b/lib/Interpreter/Interpreter.php
@@ -278,12 +278,12 @@ abstract class Interpreter {
 	 * @link http://de3.php.net/manual/en/datetime.formats.php
 	 * @todo add millisecond resolution
 	 *
-	 * @param string $ts string to parse
+	 * @param mixed $string int, float or string to parse
 	 * @param float $now in ms since 1970
 	 * @return float
 	 */
 	protected static function parseDateTimeString($string) {
-		if (ctype_digit($string)) { // handling as ms timestamp
+		if (is_numeric($string)) { // handling as ms timestamp
 			return (float) $string;
 		}
 		elseif ($ts = strtotime($string)) {


### PR DESCRIPTION
Dieser Patch ändert daher zwei Stellen:
- erlaubt Anlegen von (Entity) Controllern ohne View
- erlaubt Anlegen von Interpretern mit numerischen Parametern (bisher war String notwendig was wenig intuitiv ist)

Damit werden z.B. die folgenden Skriptzeilen möglich:

```
$em = Volkszaehler\Router::createEntityManager();

$view = null; // not needed
$ec = new Controller\EntityController($view, $em);
$entity = $ec->get($uuid);

$class = $entity->getDefinition()->getInterpreter();
$interpreter = new $class($entity, $em, 1, 1, null, null);

$tuples = $interpreter->processData(function($tuple) { return $tuple; });
```
