### PR TITLE
Improve timestamp validation fix from 9c8d8c48f34fdc671c459e10a420711637...

### DIFF
--- a/lib/Interpreter/Interpreter.php
+++ b/lib/Interpreter/Interpreter.php
@@ -283,7 +283,7 @@ abstract class Interpreter {
 	 * @return float
 	 */
 	protected static function parseDateTimeString($string) {
-		if (is_numeric($string)) { // handling as ms timestamp
+		if (ctype_digit((string)$string)) { // handling as ms timestamp
 			return (float) $string;
 		}
 		elseif ($ts = strtotime($string)) {


### PR DESCRIPTION
Detaildiskussion zu den Wundern des "loose typing" und der PHP Datenformate siehe hier: http://stackoverflow.com/questions/20607296/php-how-to-check-if-variable-is-a-large-integer

Prinzipiell fände ich es schöner wenn die Parametervalidierung die auch für den `DataController` sinnvoll wäre zentral angesiedelt wäre- m.E. sollte sie dafür nach `Model\Data`? 

Bitte um Review der Idee, dann bau ich was ;)
