### PR TITLE
Added 'materialized view' aggregation table to improve performance:

### DIFF
--- a/etc/volkszaehler.conf.template.php
+++ b/etc/volkszaehler.conf.template.php
@@ -73,6 +73,13 @@ $config['db']['dbname']				= 'volkszaehler';
 //$config['db']['admin']['password']		= 'admin_demo';
 
 /**
+ * Database aggregation
+ *
+ * See misc/tools/aggregation.php for details
+ */
+$config['aggregation'] = false;
+
+/**
  * Path of the SQLite database
  *
  * See Doctrine doc for details: http://www.doctrine-project.org/projects/dbal/2.0/docs/reference/configuration/en

--- a/htdocs/frontend/javascripts/options.js
+++ b/htdocs/frontend/javascripts/options.js
@@ -41,6 +41,7 @@ vz.options = {
 	dayNames: ['Son', 'Mon', 'Di', 'Mi', 'Do', 'Fr', 'Sam'],
 	lineWidthDefault: 2,
 	lineWidthSelected: 4,
+	speedupFactor: 2,   // higher values give higher speedup but can produce chunky display
 };
 
 vz.options.plot = {

--- a/lib/Volkszaehler/Controller/DataController.php
+++ b/lib/Volkszaehler/Controller/DataController.php
@@ -45,12 +45,12 @@ class DataController extends Controller {
 		$tuples = $this->view->request->getParameter('tuples');
 		$groupBy = $this->view->request->getParameter('group');
 		$tsFmt = $this->view->request->getParameter('tsfmt');
-		$client = strtolower($this->view->request->getParameter('client'));
+		$options = $this->view->request->getParameter('options');
 
 		// single entity
 		if ($entity) {
 			$class = $entity->getDefinition()->getInterpreter();
-			return new $class($entity, $this->em, $from, $to, $tuples, $groupBy, $client);
+			return new $class($entity, $this->em, $from, $to, $tuples, $groupBy, $options);
 		}
 
 		// multiple UUIDs
@@ -104,7 +104,7 @@ class DataController extends Controller {
 				$this->em->getConnection()->commit();
 			}
 			catch (Exception $e) {
-				$this->em->getConnection()->rollback(); 
+				$this->em->getConnection()->rollback();
 				throw($e);
 			}
 		} catch (Util\JSONException $e) { /* fallback to old method */
@@ -114,11 +114,11 @@ class DataController extends Controller {
 			if (is_null($timestamp)) {
 				$timestamp = (double) round(microtime(TRUE) * 1000);
 			}
-			
+
 			if (is_null($value)) {
 				$value = 1;
 			}
-		
+
 			$channel->addData(new Model\Data($channel, $timestamp, $value));
 			$this->em->flush();
 		}

--- a/lib/Volkszaehler/Interpreter/CounterInterpreter.php
+++ b/lib/Volkszaehler/Interpreter/CounterInterpreter.php
@@ -139,7 +139,7 @@ class CounterInterpreter extends Interpreter {
 	 * @param string $expression sql parameter
 	 * @return string grouped sql expression
 	 */
-	protected static function groupExprSQL($expression) {
+	public static function groupExprSQL($expression) {
 		return 'MAX(' . $expression . ')';
 	}
 }

--- a/lib/Volkszaehler/Interpreter/SQL/MySQLAggregateOptimizer.php
+++ b/lib/Volkszaehler/Interpreter/SQL/MySQLAggregateOptimizer.php
@@ -1,0 +1,288 @@
+<?php
+/**
+ * @copyright Copyright (c) 2013, The volkszaehler.org project
+ * @package default
+ * @license http://www.opensource.org/licenses/gpl-license.php GNU Public License
+ * @author Andreas Goetz <cpuidle@gmx.de>
+ */
+/*
+ * This file is part of volkzaehler.org
+ *
+ * volkzaehler.org is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * volkzaehler.org is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with volkszaehler.org. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Volkszaehler\Interpreter\SQL;
+
+use Volkszaehler\Interpreter;
+use Volkszaehler\Util;
+use Volkszaehler\Model;
+use Doctrine\DBAL;
+
+/**
+ * MySQLAggregateOptimizer
+ *
+ * Provides additional DB-specific optimizations by utilizing
+ * an additional 'materialized view' table.
+ *
+ * Speedup is achieved by combining main data and materialized view 'aggregate' tables
+ * into single query.
+ *
+ * Tables are 'stitched' together by evaluating suitable timestamps:
+ *
+ *     table:   --data-- -----aggregate----- -data-
+ * timestamp:   from ... aggFrom ..... aggTo ... to
+ */
+class MySQLAggregateOptimizer extends MySQLOptimizer {
+
+	protected $aggregator;
+
+	protected $aggFrom;
+	protected $aggTo;
+
+	protected $sqlTimeFilter;
+	protected $sqlTimeFilterPre;
+	protected $sqlTimeFilterPost;
+
+	/**
+	 * Must only be instantiated if config['aggregation'] = true
+	 */
+	public function __construct(Interpreter\Interpreter $interpreter, DBAL\Connection $conn) {
+		parent::__construct($interpreter, $conn);
+		$this->aggregator = new Util\Aggregation($this->conn);
+	}
+
+	public function optimizeRowCountSQL(&$sqlRowCount, &$sqlParameters) {
+		$aggregationValid = false;
+
+		// run optimizer to get best (highest) applicable aggregation level
+		$aggregationLevel = $this->aggregator->getOptimalAggregationLevel($this->channel->getUuid(), $this->groupBy);
+		if ($aggregationLevel) {
+			// choose highest level
+			$aggregationLevel = $aggregationLevel[0]['level'];
+
+			// numeric value of desired aggregation level
+			$type = Util\Aggregation::getAggregationLevelTypeValue($aggregationLevel);
+
+			// valid boundaries?
+			$aggregationValid = $this->getAggregationBoundary($aggregationLevel);
+		}
+
+		if ($aggregationValid) {
+			$sqlParameters = $this->buildAggregationTableParameters($type);
+
+			if ($this->groupBy) {
+				// optimize grouped count statement by applying aggregation table
+				$sqlGroupFields = $this->interpreter->buildGroupBySQL($this->groupBy);
+
+				$sqlRowCount = 'SELECT DISTINCT ' . $sqlGroupFields . ' ' .
+							   'FROM data WHERE channel_id = ? ' .
+							   'AND (' . $this->sqlTimeFilterPre . ' OR' . $this->sqlTimeFilterPost . ') ';
+				$sqlRowCount.= 'UNION SELECT DISTINCT ' . $sqlGroupFields . ' ' .
+							   'FROM aggregate ' .
+							   'WHERE channel_id = ? AND type = ?' . $this->sqlTimeFilter;
+				$sqlRowCount = 'SELECT COUNT(1) ' .
+							   'FROM (' . $sqlRowCount . ') AS agg';
+			}
+			else {
+				// optimize non-grouped count statement
+				$sqlRowCount = 'SELECT COUNT(1) AS count ' .
+							   'FROM data WHERE channel_id = ? ' .
+							   'AND (' . $this->sqlTimeFilterPre . ' OR' . $this->sqlTimeFilterPost . ') ';
+				$sqlRowCount.= 'UNION SELECT SUM(count) AS count ' .
+							   'FROM aggregate ' .
+							   'WHERE channel_id = ? AND type = ?' . $this->sqlTimeFilter;
+				$sqlRowCount = 'SELECT SUM(count) ' .
+							   'FROM (' . $sqlRowCount . ') AS agg';
+			}
+		}
+
+		// get upstream optimization
+		return ($aggregationValid) ?: parent::optimizeDataSQL($sql, $sqlParameters);
+	}
+
+	public function optimizeDataSQL(&$sql, &$sqlParameters) {
+		$aggregationValid = false;
+		// run optimizer to get best (highest) applicable aggregation level
+		$aggregationLevel = $this->aggregator->getOptimalAggregationLevel($this->channel->getUuid(), $this->groupBy);
+		if ($aggregationLevel) {
+			// choose highest level
+			$aggregationLevel = $aggregationLevel[0]['level'];
+
+			// numeric value of desired aggregation level
+			$type = Util\Aggregation::getAggregationLevelTypeValue($aggregationLevel);
+
+			// valid boundaries?
+			$aggregationValid = $this->getAggregationBoundary($aggregationLevel);
+		}
+
+		if ($aggregationValid) {
+			if ($this->groupBy) {
+				// optimize grouped statement
+				$sqlParameters = $this->buildAggregationTableParameters($type);
+				$sqlGroupFields = $this->interpreter->buildGroupBySQL($this->groupBy);
+
+				// 	   table:   --DATA-- -----aggregate----- -DATA-
+				$sql = 'SELECT timestamp, value, 1 AS count ' .
+					   'FROM data ' .
+					   'WHERE channel_id = ? ' .
+					   'AND (' . $this->sqlTimeFilterPre . ' OR' . $this->sqlTimeFilterPost . ') ';
+
+				// 	   table:   --data-- -----AGGREGATE----- -data-
+				$sql.= 'UNION SELECT timestamp, value, count ' .
+					   'FROM aggregate ' .
+					   'WHERE channel_id = ? AND type = ?' . $this->sqlTimeFilter;
+
+				// add common aggregation and sorting on UNIONed table
+				// (sorting applied outside UNION as MySQL doesn't guarantee UNION result ordering)
+				$sql = 'SELECT MAX(timestamp) AS timestamp, ' .
+						$this->interpreter->groupExprSQL('value') . ' AS value, SUM(count) AS count ' .
+					   'FROM (' . $sql . ') AS agg ' .
+					   'GROUP BY ' . $sqlGroupFields . ' ORDER BY timestamp ASC';
+			}
+			elseif ($this->tupleCount == 1 && ($this->rowCount > $this->tupleCount)) {
+				// optimize non-grouped statement special case: package into 1 tuple
+				$packageSize = floor($this->rowCount / $this->tupleCount);
+
+				// shift aggregation boundary start by 1 unit to make sure first tuple is not aggregated
+				$aggregationValid = $packageSize > 1 && $this->getAggregationBoundary($aggregationLevel, 1);
+
+				if ($aggregationValid) {
+					$sqlParameters = $this->buildAggregationTableParameters($type);
+
+					// 	   table:   --DATA-- -----aggregate----- -DATA-
+					$sql = 'SELECT timestamp, value, 1 AS count, @row:=@row+1 AS row ' .
+						   'FROM data ' .
+						   'WHERE channel_id = ? ' .
+						   'AND (' . $this->sqlTimeFilterPre . ' OR' . $this->sqlTimeFilterPost . ') ';
+
+					// 	   table:   --data-- -----AGGREGATE----- -data-
+					$sql.= 'UNION SELECT timestamp, value, count, @row:=@row+1 AS row ' .
+						   'FROM aggregate ' .
+						   'WHERE channel_id = ? AND type = ?' . $this->sqlTimeFilter;
+
+					// add common aggregation and sorting on UNIONed table
+					$sql = 'SELECT MAX(timestamp) AS timestamp, ' .
+							$this->interpreter->groupExprSQL('value') . ' AS value, SUM(count) AS count ' .
+						   'FROM (SELECT @row:=0) AS init, (' . $sql . ') AS agg ' .
+						   'GROUP BY row > 1 ORDER BY timestamp ASC';
+				}
+			}
+		}
+
+		// get upstream optimization
+		return ($aggregationValid) ?: parent::optimizeDataSQL($sql, $sqlParameters);
+	}
+
+	/**
+	 * Build SQL parameters for aggregation table access given timestamp boundaries
+	 * @author Andreas Goetz <cpuidle@gmx.de>
+	 */
+	private function buildAggregationTableParameters($type) {
+		$sqlParameters = array($this->channel->getId());
+
+		// timestamp:   from ... aggFrom ..... aggTo ... to
+		//     table:   --DATA-- -----aggregate----- -data-
+		$this->sqlTimeFilterPre = self::buildDateTimeFilterSQL($this->from, $this->aggFrom, $sqlParameters, true, '');
+		// 	   table:   --data-- -----aggregate----- -DATA-
+		$this->sqlTimeFilterPost = self::buildDateTimeFilterSQL($this->aggTo, $this->to, $sqlParameters, false, '');
+
+		array_push($sqlParameters, $this->channel->getId(), $type);
+		// 	   table:   --data-- -----AGGREGATE----- -data-
+		$this->sqlTimeFilter = self::buildDateTimeFilterSQL($this->aggFrom, $this->aggTo, $sqlParameters, true);
+
+		return $sqlParameters;
+	}
+
+	/**
+	 * Calculate valid timestamp boundaries for aggregation table usage
+	 *
+	 *     table:   --data-- -----aggregate----- -data-
+	 * timestamp:   from ... aggFrom ..... aggTo ... to
+	 *
+	 * @param string $type aggregation level (e.g. 'day')
+	 * @return boolean true: aggregate table contains data, aggFrom/aggTo contains valid range
+	 * @author Andreas Goetz <cpuidle@gmx.de>
+	 */
+	private function getAggregationBoundary($level, $aggFromDelta = null) {
+		$type = Util\Aggregation::getAggregationLevelTypeValue($level);
+		$dateFormat = Util\Aggregation::getAggregationDateFormat($level); // day = "%Y-%m-%d"
+
+		// aggFrom becomes beginning of first period with aggregate data
+		$sqlParameters = array($this->channel->getId(), $type, $this->from);
+		if (isset($aggFromDelta)) {
+			// shift 'left' border of aggregate table use by $aggFromDelta units
+			$sql = 'SELECT UNIX_TIMESTAMP(' .
+				   'DATE_ADD(' .
+					   'FROM_UNIXTIME(MIN(timestamp) / 1000, ' . $dateFormat . '), ' .
+					   'INTERVAL ' . $aggFromDelta . ' ' . $level .
+				   ')) * 1000 ' .
+			 	   'FROM aggregate WHERE channel_id=? AND type=? AND timestamp>=?';
+		}
+		else {
+			// find 'left' border of aggregate table after $from
+			$sql = 'SELECT UNIX_TIMESTAMP(FROM_UNIXTIME(MIN(timestamp) / 1000, ' . $dateFormat . ')) * 1000 ' .
+			 	   'FROM aggregate WHERE channel_id=? AND type=? AND timestamp>=?';
+		}
+		$this->aggFrom = $this->conn->fetchColumn($sql, $sqlParameters, 0);
+		$this->aggTo = null;
+
+		// aggregate table contains relevant data?
+		if (isset($this->aggFrom)) {
+			// aggTo becomes beginning of first period without aggregate data
+			$sqlParameters = array($this->channel->getId(), $type);
+			$sql = 'SELECT UNIX_TIMESTAMP(' .
+				   'DATE_ADD(' .
+						'FROM_UNIXTIME(MAX(timestamp) / 1000, ' . $dateFormat . '), ' .
+						'INTERVAL 1 ' . $level .
+				   ')) * 1000 ' .
+				   'FROM aggregate WHERE channel_id=? AND type=?';
+			if (isset($this->to)) {
+				$sqlParameters[] = $this->to;
+				$sql .= ' AND timestamp<?';
+			}
+			$this->aggTo = $this->conn->fetchColumn($sql, $sqlParameters, 0);
+		}
+
+		return (isset($this->aggFrom) && isset($this->aggTo));
+	}
+
+	/**
+	 * Build sql query part to filter specified time interval
+	 *
+	 * Replaces Interpreter::buildDateTimeFilterSQL
+	 *
+	 * @param integer $from timestamp in ms since 1970
+	 * @param integer $to timestamp in ms since 1970
+	 * @param boolean $sequential use < operator instead of <= for time comparison at end of period
+	 * @param string  $op initial concatenation operator
+	 * @return string the sql part
+	 */
+	public static function buildDateTimeFilterSQL($from = NULL, $to = NULL, &$parameters, $sequential = false, $op = ' AND') {
+		$sql = '';
+
+		if (isset($from)) {
+			$sql .= $op . ' timestamp >= ?';
+			$parameters[] = $from;
+		}
+
+		if (isset($to)) {
+			$sql .= (($sql) ? ' AND' : $op) . ' timestamp ' . (($sequential) ? '<' : '<=') . ' ?';
+			$parameters[] = $to;
+		}
+
+		return $sql;
+	}
+}
+
+?>

--- a/lib/Volkszaehler/Interpreter/SQL/MySQLOptimizer.php
+++ b/lib/Volkszaehler/Interpreter/SQL/MySQLOptimizer.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * @copyright Copyright (c) 2013, The volkszaehler.org project
+ * @package default
+ * @license http://www.opensource.org/licenses/gpl-license.php GNU Public License
+ * @author Andreas Goetz <cpuidle@gmx.de>
+ */
+/*
+ * This file is part of volkzaehler.org
+ *
+ * volkzaehler.org is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * volkzaehler.org is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with volkszaehler.org. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Volkszaehler\Interpreter\SQL;
+
+use Volkszaehler\Interpreter;
+use Volkszaehler\Util;
+use Volkszaehler\Model;
+use Doctrine\DBAL;
+
+/**
+ * MySQLOptimizer provides basic DB-specific optimizations
+ */
+class MySQLOptimizer extends SQLOptimizer {
+
+	/**
+	 * DB-specific data grouping by date functions
+	 *
+	 * @param string $groupBy
+	 * @return string the sql part
+	 */
+	public static function buildGroupBySQL($groupBy) {
+		$ts = 'FROM_UNIXTIME(timestamp/1000)'; // just for saving space
+
+		switch ($groupBy) {
+			case 'year':
+				return 'YEAR(' . $ts . ')';
+				break;
+
+			case 'month':
+				return 'YEAR(' . $ts . '), MONTH(' . $ts . ')';
+				break;
+
+			case 'week':
+				return 'YEAR(' . $ts . '), WEEKOFYEAR(' . $ts . ')';
+				break;
+
+			case 'day':
+				return 'YEAR(' . $ts . '), DAYOFYEAR(' . $ts . ')';
+				break;
+
+			case 'hour':
+				return 'YEAR(' . $ts . '), DAYOFYEAR(' . $ts . '), HOUR(' . $ts . ')';
+				break;
+
+			case 'minute':
+				return 'YEAR(' . $ts . '), DAYOFYEAR(' . $ts . '), HOUR(' . $ts . '), MINUTE(' . $ts . ')';
+				break;
+
+			case 'second':
+				return 'YEAR(' . $ts . '), DAYOFYEAR(' . $ts . '), HOUR(' . $ts . '), MINUTE(' . $ts . '), SECOND(' . $ts . ')';
+				break;
+
+			default:
+				return FALSE;
+		}
+	}
+
+	public function optimizeDataSQL(&$sql, &$sqlParameters) {
+		if ($this->groupBy)
+			return false;
+
+		// potential to reduce result set - can't do this for already grouped SQL
+		if ($this->tupleCount && ($this->rowCount > $this->tupleCount)) {
+			$packageSize = floor($this->rowCount / $this->tupleCount);
+
+			if ($packageSize > 1) { // worth doing -> go
+				// optimize package statement general case: tuple packaging
+				$foo = array();
+				$sqlTimeFilter = $this->interpreter->buildDateTimeFilterSQL($this->from, $this->to, $foo);
+
+				$this->rowCount = floor($this->rowCount / $packageSize);
+				// setting @row to packageSize-2 will make the first package contain 1 tuple only
+				// this pushes as much 'real' data as possible into the first used package and ensures
+				// we get 2 rows even if tuples=1 requested (first row is discarded by DataIterator)
+				$sql = 'SELECT MAX(agg.timestamp) AS timestamp, ' .
+						$this->interpreter->groupExprSQL('agg.value') . ' AS value, ' .
+					   'COUNT(agg.value) AS count ' .
+					   'FROM (SELECT @row:=' . ($packageSize-2) . ') AS init, (' .
+							 'SELECT timestamp, value, @row:=@row+1 AS row ' .
+							 'FROM data WHERE channel_id=?' . $sqlTimeFilter . ' ' .
+					   		 'ORDER BY timestamp' .
+					   ') AS agg ' .
+					   'GROUP BY row DIV ' . $packageSize . ' ' .
+					   'ORDER BY timestamp ASC';
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+}
+
+?>

--- a/lib/Volkszaehler/Interpreter/SQL/PostgreSQLOptimizer.php
+++ b/lib/Volkszaehler/Interpreter/SQL/PostgreSQLOptimizer.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @copyright Copyright (c) 2013, The volkszaehler.org project
+ * @package default
+ * @license http://www.opensource.org/licenses/gpl-license.php GNU Public License
+ * @author Andreas Goetz <cpuidle@gmx.de>
+ */
+/*
+ * This file is part of volkzaehler.org
+ *
+ * volkzaehler.org is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * volkzaehler.org is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with volkszaehler.org. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Volkszaehler\Interpreter\SQL;
+
+/**
+ * PostgreSQLOptimizer provides basic DB-specific optimizations
+ */
+class PostgreSQLOptimizer extends SQLOptimizer {
+
+	/**
+	 * DB-specific data grouping by date functions
+	 *
+	 * @param string $groupBy
+	 * @return string the sql part
+	 */
+	public static function buildGroupBySQL($groupBy) {
+		$ts = "TIMESTAMP 'epoch' + timestamp * INTERVAL '1 millisecond'"; // just for saving space
+
+		switch ($groupBy) {
+			case 'year':
+			case 'month':
+			case 'week':
+			case 'day':
+			case 'hour':
+			case 'minute':
+			case 'second':
+				return "DATE_TRUNC('" . $groupBy . "', " . $ts . ")";
+			default:
+				return FALSE;
+		}
+	}
+}
+
+?>

--- a/lib/Volkszaehler/Interpreter/SQL/SQLOptimizer.php
+++ b/lib/Volkszaehler/Interpreter/SQL/SQLOptimizer.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * @copyright Copyright (c) 2013, The volkszaehler.org project
+ * @package default
+ * @license http://www.opensource.org/licenses/gpl-license.php GNU Public License
+ * @author Andreas Goetz <cpuidle@gmx.de>
+ */
+/*
+ * This file is part of volkzaehler.org
+ *
+ * volkzaehler.org is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * volkzaehler.org is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with volkszaehler.org. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Volkszaehler\Interpreter\SQL;
+
+use Volkszaehler\Interpreter;
+use Volkszaehler\Util;
+use Volkszaehler\Model;
+use Doctrine\DBAL;
+
+/**
+ * SQLOptimizer is the base class for DB-specific optimizations
+ */
+class SQLOptimizer {
+
+	protected $interpreter;
+	protected $conn;
+
+	protected $from;
+	protected $to;
+	protected $groupBy;
+
+	/**
+	 * Factory method
+	 *
+	 * @param  InterpreterInterpreter $interpreter
+	 * @param  ModelChannel           $channel
+	 * @param  DBALConnection         $conn
+	 * @return SQL\SQLOptimizer 	  instantiated class or false
+	 */
+	public static function factory() {
+		$dbConfig = Util\Configuration::read('db');
+		switch ($dbConfig['driver']) {
+			case 'pdo_mysql':
+				if (Util\Configuration::read('aggregation')) {
+					$class = __NAMESPACE__ . '\MySQLAggregateOptimizer';
+				}
+				else {
+					$class = __NAMESPACE__ . '\MySQLOptimizer';
+				}
+				break;
+			case 'pdo_sqlite':
+				$class = __NAMESPACE__ . '\SQLiteOptimizer';
+				break;
+			case 'pdo_pgsql':
+				$class = __NAMESPACE__ . '\PostgreSQLOptimizer';
+				break;
+			default:
+				$class = __CLASS__;
+		}
+		return $class;
+	}
+
+	public function __construct(Interpreter\Interpreter $interpreter, DBAL\Connection $conn) {
+		$this->interpreter = $interpreter;
+		$this->conn = $conn;
+	}
+
+	/**
+	 * Gives access to hidden interpreter properties
+	 */
+	public function setParameters($from, $to, $tupleCount, $groupBy) {
+		$this->from = $from;
+		$this->to = $to;
+		$this->tupleCount = $tupleCount;
+		$this->groupBy = $groupBy;
+	}
+
+	/**
+	 * Proxy magic. Transparently access public interpreter properties
+	 * Keeps the code portable between Interpreter and SQLOptimizer
+	 */
+	public function __get($property) {
+		if ($property == 'channel') {
+			return $this->interpreter->getEntity();
+		}
+		elseif ($property == 'rowCount') {
+			return $this->interpreter->getRowCount();
+		}
+		elseif ($property == 'tupleCount') {
+			return $this->interpreter->getTupleCount();
+		}
+ 		else {
+   			throw new \Exception('Invalid property access: \'' . $property . '\'');
+   		}
+	}
+
+	/**
+	 * Proxy magic. Transparently access public interpreter properties
+	 * Keeps the code portable between Interpreter and SQLOptimizer
+	 */
+	public function __set($property, $value) {
+		if ($property == 'rowCount') {
+			return $this->interpreter->setRowCount($value);
+		}
+		elseif ($property == 'tupleCount') {
+			return $this->interpreter->setTupleCount($value);
+		}
+ 		else {
+   			throw new \Exception('Invalid property access: \'' . $property . '\'');
+   		}
+	}
+
+	/**
+	 * DB-specific data grouping by date functions.
+	 * Static call is degelated to implementing classes.
+	 * Called by Interpreter->buildGroupBySQL
+	 *
+	 * @param string $groupBy
+	 * @return string the sql part
+	 */
+	public static function buildGroupBySQL($groupBy) {
+		$class = self::factory();
+		// fall back on default implementation if nothing else declared
+		if ($class == __CLASS__) {
+			$class = __NAMESPACE__ . '\MySQLOptimizer';
+		}
+		return $class::buildGroupBySQL($groupBy);
+	}
+
+	/**
+	 * Called by interpreter before counting result rows
+	 *
+	 * @param  string $sqlRowCount   initial SQL query
+	 * @param  string $sqlParameters initial SQL parameters
+	 * @return boolean               optimization result
+	 */
+	public function optimizeRowCountSQL(&$sqlRowCount, &$sqlParameters) {
+		// not implemented
+		return false;
+	}
+
+	/**
+	 * Called by interpreter before retrieving result rows
+	 *
+	 * @param  string $sql  		 initial SQL query
+	 * @param  string $sqlParameters initial SQL parameters
+	 * @return boolean               optimization result
+	 */
+	public function optimizeDataSQL(&$sql, &$sqlParameters) {
+		// not implemented
+		return false;
+	}
+}
+
+?>

--- a/lib/Volkszaehler/Interpreter/SQL/SQLiteOptimizer.php
+++ b/lib/Volkszaehler/Interpreter/SQL/SQLiteOptimizer.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @copyright Copyright (c) 2013, The volkszaehler.org project
+ * @package default
+ * @license http://www.opensource.org/licenses/gpl-license.php GNU Public License
+ * @author Andreas Goetz <cpuidle@gmx.de>
+ */
+/*
+ * This file is part of volkzaehler.org
+ *
+ * volkzaehler.org is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * volkzaehler.org is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with volkszaehler.org. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Volkszaehler\Interpreter\SQL;
+
+/**
+ * SQLiteOptimizer provides basic DB-specific optimizations
+ */
+class SQLiteOptimizer extends SQLOptimizer {
+
+	/**
+	 * DB-specific data grouping by date functions
+	 *
+	 * @param string $groupBy
+	 * @return string the sql part
+	 */
+	public static function buildGroupBySQL($groupBy) {
+		$ts = ', timestamp/1000, "unixepoch"'; // just for saving space
+
+		switch ($groupBy) {
+			case 'year':
+				return 'STRFTIME("%Y"' . $ts . ')';
+				break;
+
+			case 'month':
+				return 'STRFTIME("%Y-%m"' . $ts . ')';
+				break;
+
+			case 'week':
+				return 'STRFTIME("%Y %W"' . $ts . ')';
+				break;
+
+			case 'day':
+				return 'STRFTIME("%Y-%m-%d"' . $ts . ')';
+				break;
+
+			case 'hour':
+				return 'STRFTIME("%Y-%m-%d %H"' . $ts . ')';
+				break;
+
+			case 'minute':
+				return 'STRFTIME("%Y-%m-%d %H:%M"' . $ts . ')';
+				break;
+
+			case 'second':
+				return 'STRFTIME("%Y-%m-%d %H:%M:%S"' . $ts . ')';
+				break;
+
+			default:
+				return FALSE;
+		}
+	}
+}
+
+?>

--- a/lib/Volkszaehler/Model/Aggregate.php
+++ b/lib/Volkszaehler/Model/Aggregate.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * @copyright Copyright (c) 2013, The volkszaehler.org project
+ * @package default
+ * @license http://www.opensource.org/licenses/gpl-license.php GNU Public License
+ */
+/*
+ * This file is part of volkzaehler.org
+ *
+ * volkzaehler.org is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * volkzaehler.org is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with volkszaehler.org. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Volkszaehler\Model;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Volkszaehler\Model;
+
+/**
+ * Aggregate materialized view entity
+ *
+ * @author Andreas Goetz <cpuidle@gmx.de>
+ * @package default
+ *
+ * @Entity
+ * @Table(
+ * 	name="aggregate",
+ *	indexes={@index(name="search_idx", columns={"channel_id", "type", "timestamp"})},
+ *	uniqueConstraints={@UniqueConstraint(name="ts_uniq", columns={"channel_id", "type", "timestamp"})}
+ * )
+ */
+class Aggregate {
+	/**
+	 * @Id
+	 * @Column(type="integer", nullable=false)
+	 * @GeneratedValue(strategy="AUTO")
+	 *
+	 * @todo wait until DDC-117 is fixed (PKs on FKs)
+	 */
+	protected $id;
+
+	/**
+	 * @ManyToOne(targetEntity="Channel", inversedBy="aggregate")
+	 * @JoinColumn(name="channel_id", referencedColumnName="id")
+	 *
+	 * @todo implement inverse side (Channel->aggregate)
+	 */
+	protected $channel;
+
+	/**
+	 * Aggregation type
+	 *
+	 * @Column(type="smallint")
+	 */
+	protected $type;
+
+	/**
+	 * Ending timestamp of period in ms since 1970
+	 *
+	 * @Column(type="bigint")
+	 */
+	protected $timestamp;
+
+	/**
+	 * @Column(type="float")
+	 */
+	protected $value;
+
+	/**
+	 * Aggregated row count
+	 *
+	 * @Column(type="integer")
+	 */
+	protected $count;
+
+	public function __construct(Model\Channel $channel, $type, $timestamp, $value, $count) {
+		$this->channel = $channel;
+		$this->type = $type;
+
+		$this->value = $value;
+		$this->timestamp = $timestamp;
+		$this->count = $count;
+	}
+
+	public function toArray() {
+		return array('channel' => $this->channel, 'type' => $this->type, 'timestamp' => $this->timestamp, 'value' => $this->value, 'count' => $this->count);
+	}
+
+	/**
+	 * setter & getter
+	 */
+	public function getValue() { return $this->value; }
+	public function getTimestamp() { return $this->timestamp; }
+	public function getChannel() { return $this->channel; }
+	public function getCount() { return $this->count; }
+	public function getType() { return $this->type; }
+}
+
+?>

--- a/lib/Volkszaehler/Model/Channel.php
+++ b/lib/Volkszaehler/Model/Channel.php
@@ -23,6 +23,7 @@
 
 namespace Volkszaehler\Model;
 
+use Volkszaehler\Util;
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**
@@ -64,8 +65,19 @@ class Channel extends Entity {
 	 * @todo filter from & to
 	 */
 	public function clearData(\Doctrine\ORM\EntityManager $em) {
+		$em->getConnection()->beginTransaction();
+
 		$sql = 'DELETE FROM data WHERE channel_id = ?';
-		return $em->getConnection()->executeQuery($sql, array($this->id));
+		$res = $em->getConnection()->executeQuery($sql, array($this->id));
+
+		// clean aggregation table as well
+		if (Util\Configuration::read('aggregation')) {
+			$sql = 'DELETE FROM aggregate WHERE channel_id = ?';
+			$em->getConnection()->executeQuery($sql, array($this->id));
+		}
+
+		$em->getConnection()->commit();
+		return $res;
 	}
 }
 

--- a/lib/Volkszaehler/Util/Aggregation.php
+++ b/lib/Volkszaehler/Util/Aggregation.php
@@ -1,0 +1,297 @@
+<?php
+/**
+ * Data aggregation utility
+ *
+ * @author Andreas Goetz <cpuidle@gmx.de>
+ * @copyright Copyright (c) 2013, The volkszaehler.org project
+ * @package util
+ * @license http://opensource.org/licenses/gpl-license.php GNU Public License
+ */
+/*
+ * This file is part of volkzaehler.org
+ *
+ * volkzaehler.org is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * volkzaehler.org is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with volkszaehler.org. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Volkszaehler\Util;
+
+use Volkszaehler\Util;
+use Volkszaehler\Interpreter;
+use Volkszaehler\Definition;
+use Doctrine\DBAL;
+
+class Aggregation {
+	/**
+	 * @var \Doctrine\DBAL\Connection Database connection
+	 */
+	protected $conn;
+
+	/**
+	 * @var SQL aggregation types and assorted date formats
+	 */
+	protected static $aggregationLevels = array();
+
+	/**
+	 * Initialize static variables
+	 *
+	 * @todo When changing order or this array the aggregation table must be rebuilt
+	 */
+	static function init() {
+		self::$aggregationLevels = array(
+			'second' => '"%Y-%m-%d %H:%i:%s"',	// type 0
+			'minute' => '"%Y-%m-%d %H:%i:00"',	// type 1
+			'hour' => 	'"%Y-%m-%d %H:00:00"',	// type 2
+			'day' => 	'"%Y-%m-%d"',			// type 3
+			'week' => 	null,					// type 4 - not supported
+			'month' => 	'"%Y-%m-1"',			// type 5
+			'year' => 	'"%Y-1-1"'				// type 6
+		);
+	}
+
+	public function __construct(DBAL\Connection $conn) {
+		$this->conn = $conn;
+	}
+
+	/**
+	 * Get list of aggregation levels
+	 *
+	 * @param  string  $level aggregation level (e.g. 'day')
+	 * @return boolean        validity
+	 */
+	public static function getAggregationLevels() {
+		return array_keys(self::$aggregationLevels);
+	}
+
+	/**
+	 * Test if aggregation level is valid and implemented
+	 *
+	 * @param  string  $level aggregation level (e.g. 'day')
+	 * @return boolean        validity
+	 */
+	public static function isValidAggregationLevel($level) {
+		return in_array($level, self::getAggregationLevels())
+			&& (isset(self::$aggregationLevels[$level]));
+	}
+
+	/**
+	 * Convert aggregation level to numeric type
+	 *
+	 * @param  string $level aggregation level (e.g. 'day')
+	 * @return integer       aggregation level numeric value
+	 */
+	public static function getAggregationLevelTypeValue($level) {
+		$type = array_search($level, self::getAggregationLevels(), true);
+		return($type);
+	}
+
+	/**
+	 * SQL format for grouping data by aggregation level
+	 *
+	 * @param  string $level aggregation level (e.g. 'day')
+	 * @return string        SQL date format
+	 */
+	public static function getAggregationDateFormat($level) {
+		return self::$aggregationLevels[$level];
+	}
+
+	/**
+	 * Simple optimizer - choose aggregation level with most data available
+	 *
+	 * @param  string  $targetLevel desired highest level (e.g. 'day')
+	 * @return boolean list of valid aggregation levels
+	 */
+	public function getOptimalAggregationLevel($uuid, $targetLevel = null) {
+		$levels = self::getAggregationLevels();
+
+		$sqlParameters = array($uuid);
+		$sql = 'SELECT aggregate.type, COUNT(aggregate.id) AS count ' .
+			   'FROM aggregate INNER JOIN entities ON aggregate.channel_id = entities.id ' .
+			   'WHERE uuid = ? ';
+		if ($targetLevel) {
+			$sqlParameters[] = self::getAggregationLevelTypeValue($targetLevel);
+			$sql .= 'AND aggregate.type <= ? ';
+		}
+		else {
+			$sql .= 'AND count > 0 ';
+		}
+		$sql.= 'GROUP BY type ' .
+			   'ORDER BY type DESC';
+
+		$rows = $this->conn->fetchAll($sql, $sqlParameters);
+
+		// append readable level name
+		for ($i=0; $i<count($rows); $i++) {
+			$rows[$i]['level'] = $levels[$rows[$i]['type']];
+		}
+
+		return count($rows) ? $rows : FALSE;
+	}
+
+	/**
+	 * Remove aggregration data - either all or selected type
+	 *
+	 * @param  string $level aggregation level to remove data for
+	 * @return int 			 number of affected rows
+	 */
+	public function clear($uuid = null, $level = 'all') {
+		$sqlParameters = array();
+
+		if ($level == 'all') {
+			if ($uuid) {
+				$sql = 'DELETE aggregate FROM aggregate ' .
+					   'INNER JOIN entities ON aggregate.channel_id = entities.id ' .
+					   'WHERE entities.uuid = ?';
+				$sqlParameters[] = $uuid;
+			}
+			else {
+				$sql = 'TRUNCATE TABLE aggregate';
+			}
+		}
+		else {
+			$sqlParameters[] = self::getAggregationLevelTypeValue($level);
+			$sql = 'DELETE aggregate FROM aggregate ' .
+				   'INNER JOIN entities ON aggregate.channel_id = entities.id ' .
+				   'WHERE aggregate.type = ? ';
+			if ($uuid) {
+				$sql .= 'AND entities.uuid = ?';
+				$sqlParameters[] = $uuid;
+			}
+		}
+
+		if (Util\Debug::isActivated())
+			echo(Util\Debug::getParametrizedQuery($sql, $sqlParameters)."\n");
+
+		$rows = $this->conn->executeQuery($sql, $sqlParameters);
+	}
+
+	/**
+	 * Core data aggregation
+	 *
+	 * @param  int 	  $channel_id  id of channel to perform aggregation on
+	 * @param  string $interpreter interpreter class name
+	 * @param  string $mode        aggregation mode (full, delta)
+	 * @param  string $level       aggregation level (day...)
+	 * @param  int 	  $period      delta days to aggregate
+	 * @return int    number of rows
+	 */
+	protected function aggregateChannel($channel_id, $interpreter, $mode, $level, $period) {
+		$format = self::getAggregationDateFormat($level);
+		$type = self::getAggregationLevelTypeValue($level);
+
+		// get interpreter's aggregation function
+		$aggregationFunction = $interpreter::groupExprSQL('value');
+
+		$sqlParameters = array($type);
+		$sql = 'REPLACE INTO aggregate (channel_id, type, timestamp, value, count) ' .
+			   'SELECT channel_id, ? AS type, MAX(timestamp) AS timestamp, ' .
+			   $aggregationFunction . ' AS value, COUNT(timestamp) AS count ' .
+			   'FROM data WHERE ';
+
+		// selected channel only
+		if ($channel_id) {
+			$sqlParameters[] = $channel_id;
+			$sql .= 'channel_id = ? ';
+		}
+
+		// since last aggregation only
+		if ($mode == 'delta') {
+			if ($channel_id) {
+				// selected channel
+				$sqlTimestamp = 'SELECT UNIX_TIMESTAMP(DATE_ADD(' .
+						   	   		   'FROM_UNIXTIME(MAX(timestamp) / 1000, ' . $format . '), ' .
+						   	   		   'INTERVAL 1 ' . $level . ')) * 1000 ' .
+							   	'FROM aggregate ' .
+							   	'WHERE type = ? AND channel_id = ?';
+				if ($ts = $this->conn->fetchColumn($sqlTimestamp, array($type, $channel_id), 0)) {
+					$sqlParameters[] = $ts;
+					$sql .= 'AND timestamp >= ? ';
+				}
+			}
+			else {
+				// all channels
+				$sqlParameters[] = $type;
+				$sql .=
+				   'AND timestamp >= IFNULL((' .
+				   	   'SELECT UNIX_TIMESTAMP(DATE_ADD(' .
+				   	   		  'FROM_UNIXTIME(MAX(timestamp) / 1000, ' . $format . '), ' .
+				   	   		  'INTERVAL 1 ' . $level . ')) * 1000 ' .
+					   'FROM aggregate ' .
+					   'WHERE type = ? AND aggregate.channel_id = data.channel_id ' .
+				   '), 0) ';
+			}
+		}
+
+		// selected number of periods only
+		if ($period) {
+			$sql .=
+			   'AND timestamp >= (SELECT UNIX_TIMESTAMP(DATE_SUB(DATE_FORMAT(NOW(), ' . $format . '), INTERVAL ? ' . $level . ')) * 1000) ';
+			$sqlParameters[] = $period;
+		}
+
+		// up to before current period
+		$sql.= 'AND timestamp < UNIX_TIMESTAMP(DATE_FORMAT(NOW(), ' . $format . ')) * 1000 ' .
+			   'GROUP BY channel_id, ' . Interpreter\Interpreter::buildGroupBySQL($level);
+
+		if (Util\Debug::isActivated())
+			echo(Util\Debug::getParametrizedQuery($sql, $sqlParameters)."\n");
+
+		$rows = $this->conn->executeUpdate($sql, $sqlParameters);
+
+		return($rows);
+	}
+
+	/**
+	 * Core data aggregation wrapper
+	 *
+	 * @param  string $uuid   channel UUID
+	 * @param  string $level  aggregation level (e.g. 'day')
+	 * @param  string $mode   'full' or 'delta' aggretation
+	 * @param  int    $period number of prior periods to aggregate in delta mode
+	 * @return int         	  number of affected rows
+	 */
+	public function aggregate($uuid = null, $level = 'day', $mode = 'full', $period = null) {
+		// validate settings
+		if (!in_array($mode, array('full', 'delta'))) {
+			throw new \Exception('Unsupported aggregation mode ' . $mode);
+		}
+		if (!$this->isValidAggregationLevel($level)) {
+			throw new \Exception('Unsupported aggregation level ' . $level);
+		}
+
+		// get channel definition to select correct aggregation function
+		$sqlParameters = array('channel');
+		$sql = 'SELECT id, uuid, type FROM entities WHERE class = ?';
+		if ($uuid) {
+			$sqlParameters[] = $uuid;
+			$sql .= ' AND uuid = ?';
+		}
+
+		$rows = 0;
+
+		// aggregate each channel
+		foreach ($this->conn->fetchAll($sql, $sqlParameters) as $row) {
+			$entity = Definition\EntityDefinition::get($row['type']);
+			$interpreter = $entity->getInterpreter();
+
+			$rows += $this->aggregateChannel($row['id'], $interpreter, $mode, $level, $period);
+		}
+
+		return($rows);
+	}
+}
+
+// initialize static variables
+Aggregation::init();
+
+?>

--- a/lib/Volkszaehler/Util/Console.php
+++ b/lib/Volkszaehler/Util/Console.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Console parameter handling
+ *
+ * @author Andreas Goetz <cpuidle@gmx.de>
+ * @copyright Copyright (c) 2013, The volkszaehler.org project
+ * @package util
+ * @license http://opensource.org/licenses/gpl-license.php GNU Public License
+ */
+/*
+ * This file is part of volkzaehler.org
+ *
+ * volkzaehler.org is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * volkzaehler.org is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with volkszaehler.org. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Volkszaehler\Util;
+
+class Console {
+
+	protected $parameters;
+
+	protected $options;
+	protected $commands;
+
+	/**
+	 * @param array $options Associative short/long options array in getopt syntax
+	 */
+	public function __construct($argv, $parameters) {
+		$this->parameters = $parameters;
+
+		$this->options = getopt(join('', array_keys($parameters)), array_values($parameters));
+
+		$this->commands = array();
+		for ($i=1; $i<count($argv); $i++) {
+			$arg = $argv[$i];
+			if (preg_match('#^[-/]+(.+)#', $arg, $m)) {
+				// skip argv if option is set
+				if (in_array($m[1], array_keys($this->options))) {
+					$i++;
+				}
+				continue;
+			}
+			$this->commands[] = $arg;
+		}
+	}
+
+	/**
+	 * Get cmd line commands
+	 * @param  string $command return true of command is defined
+	 * @return mixed           true/false if command specified or array of defined commands
+	 */
+	public function getCommand($command = null) {
+		if (isset($command)) {
+			return in_array($command, $this->commands);
+		}
+		else {
+			return $this->commands;
+		}
+	}
+
+	/**
+	 * Get short or long options value
+	 * @param  string $parameter short or long parameter name
+	 * @return array         	 options, FALSE if not set
+	 */
+	function getOption($parameter, $default = false) {
+		$candidates = array($parameter);
+
+		// add matching short/long options to candidates
+		if (in_array($parameter, array_keys($this->parameters))) {
+			$candidates[] = $this->parameters[$parameter];
+		}
+		elseif ($key = array_search($parameter, $this->parameters)) {
+			$candidates[] = $key;
+		}
+
+		$val = array();
+
+		// find option values
+		foreach ($candidates as $candidate) {
+			if (isset($this->options[$candidate])) {
+				$optVal = $this->options[$candidate];
+				if (is_array($optVal))
+					$val = array_merge($val, $optVal);
+				else
+					$val[] = $optVal;
+			}
+		}
+
+		return count($val) ? $val : $default;
+	}
+
+	/**
+	 * Check if script is run from console
+	 */
+	public static function isConsole() {
+		return php_sapi_name() == 'cli' || (isset($_SERVER['SESSIONNAME']) && $_SERVER['SESSIONNAME'] == 'Console');
+	}
+}
+
+?>

--- a/lib/Volkszaehler/Util/Debug.php
+++ b/lib/Volkszaehler/Util/Debug.php
@@ -79,20 +79,20 @@ class Debug {
 			$level = self::$instance->level;
 
 			$message = array('message' => $message);
-
+			
 			if ($level > 2) {
 				$message['file'] = $info['file'];
 				$message['line'] = $info['line'];
 			}
-
+			
 			if ($level > 4) {
 				$message['args'] = array_slice($info['args'], 1);
 			}
-
+			
 			if ($level > 5) {
 				$message['trace'] = array_slice($trace, 1);
 			}
-
+			
 			self::$instance->messages[] = $message;
 		}
 	}
@@ -114,6 +114,30 @@ class Debug {
 	public function getQueries() { return $this->sqlLogger->queries; }
 
 	/**
+	 * getParametrizedQuery helper function
+	 */
+	private static function formatSQLParameter($para) {
+		if (is_numeric($para)) {
+			return $para;
+		}
+		elseif (is_string($para)) {
+			return (strtoupper($para) == 'NULL') ?: "'" . $para . "'";
+		}
+		return $para;
+	}
+
+	/**
+	 * @return format SQL string with parameters
+	 * @author Andreas Goetz <cpuidle@gmx.de>
+	 */
+	public static function getParametrizedQuery($sql, $sqlParameters) {
+		while (count($sqlParameters)) {
+			$sql = preg_replace('/\?/', self::formatSQLParameter(array_shift($sqlParameters)), $sql, 1);
+		}
+		return $sql;
+	}
+
+	/**
 	 * @return 2 dimensional array with messages
 	 */
 	public function getMessages() { return $this->messages; }
@@ -123,15 +147,15 @@ class Debug {
 	 * @todo encapsulate in state class? or inherit from singleton class?
 	 */
 	public static function getInstance() { return self::$instance; }
-
+	
 	/**
 	 * @return integer current debug level
 	 */
 	 public function getLevel() { return $this->level; }
-
+	
 	/**
 	 * Tries to determine the current SHA1 hash of your git commit
-	 *
+	 * 
 	 * @return string the hash
 	 */
 	public static function getCurrentCommit() {
@@ -146,17 +170,17 @@ class Debug {
 			return FALSE;
 		}
 	}
-
+	
 	public static function getPhpVersion() {
 		return phpversion();
 	}
-
+	
 	/**
 	 * Get average server load
 	 *
 	 * @return array average load (1min, 5min, 15min)
 	 */
-	public static function getLoadAvg() {
+	public static function getLoadAvg() { 
 		if (function_exists('sys_getloadvg')) {
 			$load = sys_getloadvg();
 		}
@@ -167,10 +191,10 @@ class Debug {
 		elseif (function_exists('shell_exec')) {
 			$load = explode(', ', substr(shell_exec('uptime'), -16));
 		}
-
+		
 		return (isset($load)) ? array_map('floatval', $load) : FALSE;
 	}
-
+	
 	/**
 	 * Get server uptime
 	 *

--- a/misc/tools/aggregate.php
+++ b/misc/tools/aggregate.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Data aggregation command line tool
+ *
+ * To setup aggregation job run crontab -e
+ * 0 0 * * * /usr/bin/php cron.php
+ *
+ * @author Andreas Goetz <cpuidle@gmx.de>
+ * @copyright Copyright (c) 2013, The volkszaehler.org project
+ * @package tools
+ * @license http://opensource.org/licenses/gpl-license.php GNU Public License
+ */
+/*
+ * This file is part of volkzaehler.org
+ *
+ * volkzaehler.org is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * volkzaehler.org is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with volkszaehler.org. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use Volkszaehler\Util;
+
+define('VZ_DIR', realpath(__DIR__ . '/../..'));
+
+require_once VZ_DIR . '/lib/bootstrap.php';
+
+/**
+ * @author Andreas Goetz <cpuidle@gmx.de>
+ */
+class Cron {
+	/**
+	 * @var \Doctrine\ORM\EntityManager Doctrine EntityManager
+	 */
+	protected $em;
+
+	protected $aggregator;
+
+	public function __construct() {
+		$this->em = Volkszaehler\Router::createEntityManager(true); // get admin credentials
+	}
+
+	/**
+	 * Aggregate channel
+	 */
+	public function aggregate($uuid, $levels, $mode, $period) {
+		// loop through all aggregation levels
+		foreach ($levels as $level) {
+			if (!Util\Aggregation::isValidAggregationLevel($level))
+				throw new \Exception('Unsupported aggregation level ' . $level);
+
+			$msg = "Performing '" . $mode . "' aggregation";
+			if ($uuid) $msg .= " for UUID " . $uuid;
+			echo($msg . " on '" . $level . "' level.\n");
+			$rows = $this->aggregator->aggregate($uuid, $level, $mode, $period);
+			echo("Updated $rows rows.\n");
+		}
+	}
+
+	/**
+	 * Clear aggregate table for channel
+	 * @todo add levels support
+	 */
+	public function clear($uuid) {
+		$msg = "Clearing aggregation table";
+		if ($uuid) $msg .= " for UUID " . $uuid;
+		echo($msg . ".\n");
+		$this->aggregator->clear($uuid);
+		echo("Done clearing aggregation table.\n");
+	}
+
+	public function run($command, $uuids, $levels, $mode, $period = null) {
+		$this->aggregator = new Util\Aggregation($this->em->getConnection());
+
+		if (!in_array($mode, array('full', 'delta')))
+			throw new \Exception('Unsupported aggregation mode ' . $mode);
+
+		$conn = $this->em->getConnection();
+
+		if ($command == 'create') {
+			echo("Recreating aggregation table.\n");
+			$conn->executeQuery('DROP TABLE IF EXISTS `aggregate`');
+			$conn->executeQuery(
+				'CREATE TABLE `aggregate` (' .
+				'  `id` int(11) NOT NULL AUTO_INCREMENT,' .
+				'  `channel_id` int(11) NOT NULL,' .
+				'  `type` tinyint(1) NOT NULL,' .
+				'  `timestamp` bigint(20) NOT NULL,' .
+				'  `value` double NOT NULL,' .
+				'  `count` int(11) NOT NULL,' .
+				'  PRIMARY KEY (`id`),' .
+				'  UNIQUE KEY `ts_uniq` (`channel_id`,`type`,`timestamp`)' .
+				')');
+		}
+		elseif ($command == 'optimize') {
+			echo("Optimizing aggregate table.\n");
+			$conn->executeQuery('OPTIMIZE TABLE aggregate');
+			echo("Optimizing data table (slow).\n");
+			$conn->executeQuery('OPTIMIZE TABLE data');
+		}
+		elseif ($command == 'clear') {
+			// loop through all uuids
+			if (is_array($uuids)) {
+				foreach ($uuids as $uuid) {
+					$this->clear($uuid, $levels, $mode, $period);
+				}
+			}
+			else {
+				$this->clear(null, $levels, $mode, $period);
+			}
+		}
+		elseif ($command == 'aggregate' || $command == 'run') {
+			// loop through all uuids
+			if (is_array($uuids)) {
+				foreach ($uuids as $uuid) {
+					$this->aggregate($uuid, $levels, $mode, $period);
+				}
+			}
+			else {
+				$this->aggregate(null, $levels, $mode, $period);
+			}
+		}
+		else
+			throw new \Exception('Unknown command ' . $command);
+	}
+}
+
+$console = new Util\Console($argv, array('u:'=>'uuid:', 'm:'=>'mode:', 'l:'=>'level', 'p:'=>'period', 'h'=>'help'));
+
+if ($console::isConsole()) {
+	$help    = $console->getOption('h');
+	$uuid    = $console->getOption('u');
+	$mode    = $console->getOption('m', array('delta'));
+	$level   = $console->getOption('l', array('day'));
+	$period  = $console->getOption('p');
+
+	$commands = $console->getCommand();
+
+	if ($help || count($commands) == 0) {
+		echo("Usage: aggregate.php [options] command[s]\n");
+		echo("Commands:\n");
+		echo("       aggregate|run Run aggregation\n");
+		echo("              create Create aggregation table (DESTRUCTIVE)\n");
+		echo("               clear Clear aggregation table\n");
+		echo("            optimize Opimize data and aggregate tables\n");
+		echo("Options:\n");
+		echo("             -u[uid] uuid\n");
+		echo("            -l[evel] hour|day|month|year\n");
+		echo("             -m[ode] full|delta\n");
+		echo("           -p[eriod] number of previous time periods\n");
+		echo("Example:\n");
+		echo("         aggregate.php --uuid ABCD-0123 --mode delta -l month\n");
+		echo("Create monthly and daily aggregation data since last run for specified UUID\n");
+	}
+
+	$cron = new Cron();
+
+	foreach ($commands as $command) {
+		$cron->run($command, $uuid, $level, $mode[0], $period[0]);
+	}
+}
+else
+	throw new \Exception('This tool can only be run locally.');
+
+?>

--- a/test/Tests/AggregationPerformanceTest.php
+++ b/test/Tests/AggregationPerformanceTest.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Aggregation performance tests
+ *
+ * @package Test
+ * @author Andreas Götz <cpuidle@gmx.de>
+ */
+
+namespace Tests;
+
+use Volkszaehler\Util;
+use Volkszaehler\Model;
+use Doctrine\DBAL;
+
+class AggregationPerformanceTest extends DataContextPerformance
+{
+	static $uuid = '00000000-0000-0000-0000-000000000000';
+	static $to; // = '10.1.2000'; // limit data set for low performance clients
+	static $base;
+
+	/**
+	 * Create DB connection and setup channel
+	 */
+	static function setupBeforeClass() {
+		parent::setupBeforeClass();
+
+		self::$base = self::$context . '/' . static::$uuid . '.json?';
+
+		if (!static::$uuid) {
+			echo("Failure: need UUID before test.\nRun `phpunit Tests\SetupPerformanceData` to generate.");
+			die;
+		}
+
+		if (isset(self::$to)) {
+			if (!is_numeric(self::$to)) {
+				self::$to = strtotime(self::$to) * 1000;
+			}
+		}
+	}
+
+	/**
+	 * Cleanup aggregation
+	 */
+	static function tearDownAfterClass() {
+		// keep channel
+	}
+
+	/**
+	 * Run before each test
+	 */
+	function setUp() {
+		static::clearCache();
+		static::$time = microtime(true);
+	}
+
+	/**
+	 * @group aggregation
+	 * @group slow
+	 */
+	function testConfiguration() {
+		$this->assertTrue(Util\Configuration::read('aggregation'), 'data aggregation not enabled in config file, set $config[\'aggregation\'] = true');
+	}
+
+	/**
+	 * @depends testConfiguration
+	 * @group aggregation
+	 * @group slow
+	 */
+	function testAggregation() {
+		$rowsData = $this->countRows(static::$uuid);
+		$this->assertGreaterThan(0, $rowsData);
+		echo($this->formatMsg("DataRows") . number_format($rowsData, 0, '.', '.'));
+
+		$agg = new Util\Aggregation(self::$conn);
+		$aggLevels = $agg->getOptimalAggregationLevel(static::$uuid);
+
+		foreach ($aggLevels as $level) {
+			$rowsAgg = $this->countAggregationRows(static::$uuid, $level['type']);
+			$this->assertGreaterThan(0, $rowsAgg);
+			echo($this->formatMsg("AggregateRows  (" . $level['level'] . ")") . number_format($rowsAgg, 0, '.', '.'));
+			echo($this->formatMsg("AggregateRatio (" . $level['level'] . ")") . "1:" . round($rowsData / $rowsAgg));
+		}
+	}
+
+	// function testGetAllData() {
+	// 	$this->getTuplesByUrl(self::$base, 1, '1.2.2000', null, null, 'options=slow');
+	// 	$this->perf("GetAllPerf");
+	// }
+
+	// function testGetAllData2() {
+	// 	$this->getTuplesByUrl(self::$base, 1, '1.2.2000', null, null);
+	// 	$this->perf("GetAllPerf (opt)", true);
+	// }
+
+	/**
+	 * @depends testConfiguration
+	 * @group aggregation
+	 * @group slow
+	 */
+	function testGetAllDataGrouped() {
+		$this->getTuplesByUrl(self::$base, 1, self::$to, 'day', null, 'options=slow');
+		$this->perf("GetGroupPerf");
+	}
+
+	/**
+	 * @depends testConfiguration
+	 * @group aggregation
+	 * @group slow
+	 */
+	function testGetAllDataGrouped2() {
+		$this->getTuplesByUrl(self::$base, 1, self::$to, 'day', null);
+		$this->perf("GetGroupPerf (opt)", true);
+	}
+
+	/**
+	 * @depends testConfiguration
+	 * @group aggregation
+	 * @group slow
+	 */
+	function testGetTotal() {
+		$this->getTuplesByUrl(self::$base, 1, self::$to, null, 1, 'options=slow');
+		$this->perf("GetTotalPerf");
+	}
+
+	/**
+	 * @depends testConfiguration
+	 * @group aggregation
+	 * @group slow
+	 */
+	function testGetTotal2() {
+		$this->getTuplesByUrl(self::$base, 1, self::$to, null, 1);
+		$this->perf("GetTotalPerf (opt)", true);
+	}
+}
+
+?>

--- a/test/Tests/AggregationTest.php
+++ b/test/Tests/AggregationTest.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Aggregation tests
+ *
+ * @package Test
+ * @author Andreas Götz <cpuidle@gmx.de>
+ */
+
+namespace Tests;
+
+use Volkszaehler\Util;
+use Doctrine\DBAL;
+
+class AggregationTest extends DataContextPerformance
+{
+	/**
+	 * Create DB connection and setup channel
+	 */
+	static function setupBeforeClass() {
+		parent::setupBeforeClass();
+
+		if (!self::$uuid)
+			self::$uuid = self::createChannel('Aggregation', 'power', 100);
+	}
+
+	/**
+	 * Cleanup aggregation
+	 */
+	static function tearDownAfterClass() {
+		if (self::$conn && self::$uuid && Util\Configuration::read('aggregation')) {
+			$agg = new Util\Aggregation(self::$conn);
+			$agg->clear(self::$uuid);
+		}
+		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * All tests depend on aggreation being enabled
+	 * @group aggregation
+	 */
+	function testConfiguration() {
+		$this->assertTrue(Util\Configuration::read('aggregation'), 'data aggregation not enabled in config file, set $config[\'aggregation\'] = true');
+	}
+
+	/**
+	 * @depends testConfiguration
+	 * @group aggregation
+	 */
+	function testClearAggregation() {
+		$agg = new Util\Aggregation(self::$conn);
+		$agg->clear(self::$uuid);
+
+		$rows = $this->countAggregationRows();
+		$this->assertEquals(0, $rows, 'aggregate table cannot be cleared');
+	}
+
+	/**
+	 * @depends testClearAggregation
+	 * @group aggregation
+	 */
+	function testDeltaAggregation() {
+		$agg = new Util\Aggregation(self::$conn);
+
+		// 0:00 today current timezone - must not be aggregated
+		$this->addTuple(strtotime('today 0:00') * 1000, 50);
+		$agg->aggregate(self::$uuid, 'day', 'delta', 2);
+
+		$rows = $this->countAggregationRows();
+		$this->assertEquals(0, $rows, 'current period wrongly appears in aggreate table');
+
+		// 0:00 last two days - must be aggregated
+		$this->addTuple(strtotime('1 days ago 0:00') * 1000, 100);
+		$this->addTuple(strtotime('1 days ago 12:00') * 1000, 100);
+		$this->addTuple(strtotime('2 days ago 0:00') * 1000, 100);
+		$this->addTuple(strtotime('2 days ago 12:00') * 1000, 100);
+		$agg->aggregate(self::$uuid, 'day', 'delta', 2);
+
+		$rows = $this->countAggregationRows();
+		$this->assertEquals(2, $rows, 'last period missing from aggreate table');
+
+		// 0:00 three days ago - must not be aggregated
+		$this->addTuple(strtotime('3 days ago 0:00') * 1000, 50);
+		$agg->aggregate(self::$uuid, 'day', 'delta', 2);
+
+		$rows = $this->countAggregationRows();
+		$this->assertEquals(2, $rows, 'period before last wrongly appears in aggreate table');
+	}
+
+	/**
+	 * @depends testDeltaAggregation
+	 * @group aggregation
+	 */
+	function testDeltaAggregationSecondChannel() {
+		$agg = new Util\Aggregation(self::$conn);
+
+		// create 2nd channel
+		$uuid2 = self::createChannel('AggregationSecondChannel', 'power', 100);
+
+		// 0:00 last yesterday - must be aggregated
+		$this->addTuple(strtotime('1 days ago 0:00') * 1000, 100, $uuid2);
+		$agg->aggregate($uuid2, 'day', 'delta', 2);
+
+		$rows = $this->countAggregationRows($uuid2);
+		$this->assertEquals(1, $rows, 'repeated delta aggregation failed');
+
+		// cleanup 2nd channel
+		self::deleteChannel($uuid2);
+	}
+
+	/**
+	 * @depends testClearAggregation
+	 * @depends testDeltaAggregation
+	 * @depends testConfiguration
+	 * @group aggregation
+	 */
+	function testGetBaseline() {
+		$agg = new Util\Aggregation(self::$conn);
+		$agg->clear(self::$uuid);
+
+		// unaggregated datapoints - 6 rows
+		$this->getTuplesRaw(strtotime('3 days ago 0:00') * 1000);
+		$this->assertEquals(6, $this->json->data->rows);
+
+		// unaggregated datapoints grouped - 4 rows for comparison
+		$this->getTuplesRaw(strtotime('3 days ago 0:00') * 1000, null, 'day');
+		$this->assertEquals(4, $this->json->data->rows);
+
+		// save baseline, then aggregate
+		$tuples = $this->json->data->tuples;
+		$agg->aggregate(self::$uuid, 'day', 'delta', 2);
+
+		// aggregated datapoints grouped - 4 rows for comparison
+		$this->getTuplesRaw(strtotime('3 days ago 0:00') * 1000, null, 'day');
+		$this->assertEquals(4, $this->json->data->rows);
+
+		foreach($this->json->data->tuples as $tuple) {
+			$t = array_shift($tuples);
+			$this->assertTuple($t, $tuple);
+		}
+	}
+
+	/**
+	 * @depends testGetBaseline
+	 * @group aggregation
+	 */
+	function testAggregateRetrievalFrom() {
+		// 1 data
+		$this->getTuplesRaw(strtotime('today 0:00') * 1000, null, 'day');
+		$this->assertEquals(1, $this->json->data->rows);
+
+		// 1 agg + 1 data
+		$this->getTuplesRaw(strtotime('1 days ago 0:00') * 1000, null, 'day');
+		$this->assertEquals(2, $this->json->data->rows);
+
+		//  1 agg + 1 agg + 1 data
+		$this->getTuplesRaw(strtotime('2 days ago 0:00') * 1000, null, 'day');
+		$this->assertEquals(3, $this->json->data->rows);
+
+		// 1 data + 1 agg + 1 agg + 1 data
+		$this->getTuplesRaw(strtotime('3 days ago 0:00') * 1000, null, 'day');
+		$this->assertEquals(4, $this->json->data->rows);
+	}
+
+	/**
+	 * @depends testGetBaseline
+	 * @group aggregation
+	 */
+	function testAggregateRetrievalTo() {
+		// 1 data + 1 agg + 1 agg + 1 data
+		$this->getTuplesRaw(strtotime('3 days ago 0:00') * 1000, strtotime('today 18:00') * 1000, 'day');
+		$this->assertEquals(4, $this->json->data->rows);
+
+		// 1 data + 1 agg + 1 data(aggregated)
+		$this->getTuplesRaw(strtotime('3 days ago 0:00') * 1000, strtotime('1 days ago 6:00') * 1000, 'day');
+		$this->assertEquals(3, $this->json->data->rows);
+
+		// 1 data + 1 data(aggregated)
+		$this->getTuplesRaw(strtotime('3 days ago 0:00') * 1000, strtotime('2 days ago 6:00') * 1000, 'day');
+		$this->assertEquals(2, $this->json->data->rows);
+
+		// 1 data
+		$this->getTuplesRaw(strtotime('3 days ago 0:00') * 1000, strtotime('3 days ago 18:00') * 1000, 'day');
+		$this->assertEquals(1, $this->json->data->rows);
+	}
+
+	/**
+	 * @depends testGetBaseline
+	 * @group aggregation
+	 */
+	function testAggregateOptimizer() {
+		// 3 data, cannot use daily aggregates for hourly request
+		$this->getTuplesRaw(strtotime('2 days ago 0:00') * 1000, strtotime('1 days ago 0:00') * 1000, 'hour');
+		$this->assertEquals(3, $this->json->data->rows, 'Possibly wrong aggregation level chosen by optimizer');
+	}
+
+	/**
+	 * @depends testConfiguration
+	 * @group aggregation
+	 */
+	function testFullAggregation() {
+		// currently not implemented for performance reasons
+		echo('not implemented');
+	}
+}
+
+?>

--- a/test/Tests/DataContextPerformance.php
+++ b/test/Tests/DataContextPerformance.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Performance test base functions
+ *
+ * @package Test
+ * @author Andreas Götz <cpuidle@gmx.de>
+ */
+
+namespace Tests;
+
+use Volkszaehler\Util;
+use Volkszaehler\Model;
+use Doctrine\DBAL;
+
+class DataContextPerformance extends DataContext
+{
+	protected static $conn;
+	protected static $em;
+
+	protected static $time;		// timestamp for performance tests
+	protected static $baseline;	// timestamp for speedup comparison tests
+
+	const MSG_WIDTH = 30;
+
+	/**
+	 * Create DB connection and setup channel
+	 */
+	static function setupBeforeClass() {
+		parent::setupBeforeClass();
+
+		self::$em = \Volkszaehler\Router::createEntityManager();
+		self::$conn = self::$em->getConnection();
+	}
+
+	protected static function getChannelByUUID($uuid) {
+		$dql = 'SELECT a, p
+			FROM Volkszaehler\Model\Entity a
+			LEFT JOIN a.properties p
+			WHERE a.uuid = :uuid';
+
+		$q = self::$em->createQuery($dql);
+		$q->setParameter('uuid', $uuid);
+
+		return $q->getSingleResult();
+	}
+
+	protected static function countRows($uuid, $table = 'data') {
+		return self::$conn->fetchColumn(
+			'SELECT COUNT(1) FROM ' . $table . ' ' .
+			'INNER JOIN entities ON ' . $table . '.channel_id = entities.id ' .
+			'WHERE entities.uuid = ?', array(($uuid) ?: static::$uuid)
+		);
+	}
+
+	protected static function countAggregationRows($uuid = null, $type = null) {
+		$sql =
+			'SELECT COUNT(1) FROM aggregate ' .
+			'INNER JOIN entities ON aggregate.channel_id = entities.id ' .
+			'WHERE entities.uuid = ? ';
+		$sqlParameters = array(($uuid) ?: static::$uuid);
+
+		if (isset($type)) {
+			$sql .= 'AND aggregate.type = ?';
+			$sqlParameters[] = $type;
+		}
+
+		return self::$conn->fetchColumn($sql, $sqlParameters);
+	}
+
+	protected static function clearCache() {
+		self::$conn->executeQuery('FLUSH TABLES');
+		self::$conn->executeQuery('RESET QUERY CACHE');
+	}
+
+	protected function formatMsg($msg) {
+		$msg = "\n" . $msg . ' ';
+		while (strlen($msg) < self::MSG_WIDTH) {
+			$msg .= '.';
+		}
+		return $msg  . ' ';
+	}
+
+	protected function perf($msg, $speedup = false) {
+		$time = microtime(true) - self::$time;
+		if (!$speedup) self::$baseline = $time;
+
+		$timeStr = sprintf(($time >= 1000) ? "%.0f" : "%.2f", $time);
+		echo($this->formatMsg($msg) . $timeStr . "s ");
+
+		if ($speedup) {
+			$speedup = self::$baseline / $time;
+			echo('x' . sprintf("%.".max(0,2-floor(log($speedup,10)))."f", $speedup) . ' ');
+		}
+	}
+}
+
+?>


### PR DESCRIPTION
Detaildiskussion siehe hier: http://demo.volkszaehler.org/pipermail/volkszaehler-users/2013-December/003216.html
Standardmäßig ist die Optimierung deaktiviert um bei Upgrades keine Fehlermeldungen zu produzieren.

**Datenbankunterstützung**

  Neben verbesserter Performance von Middleware und Frontend wird auch die Kompatibilität mit SQlite und PostgreSQL hergestellt. Performanceoptimierung ist jedoch ausschließlich auf MySQL verfügbar.

**Um die Performanceoptimierung aktivieren:**
1. Hilfstabelle anlegen (nur einmalig bei Upgrade notwendig, nicht bei Neuinstallation):
   
   ```
   php misc/tools/aggregate.php create
   ```
2. Hilfstabelle befüllen:
   
   ```
   php misc/tools/aggregate.php -m full -l day -l hour run
   ```
3. Nutzung der Hilfstablle aktivieren:
   
   ```
   $config['aggregation'] = true;
   ```
   
   in der `etc/volkszaehler.conf.php` aktivieren.
4. Und den Prozess für die Aktualisierung noch automatisien:
   
   ```
   crontab -e
   ```
   
   und die folgenden Zeilen hinzufügen:
   
   ```
     * 2 * * * /usr/bin/php aggregate.php -m delta -l day run
     9 * * * * /usr/bin/php aggregate.php -m delta -l hour run
   ```

**Performance Test Results (opt = optimierte Version):**

```
DataRows .................... 525.600
AggregateRows  (day) ........ 365
AggregateRatio (day) ........ 1:1440.
GetGroupPerf ................ 27.26s .
GetGroupPerf (opt) .......... 0.20s x135
GetTotalPerf ................ 35.12s .
GetTotalPerf (opt) .......... 0.21s x166
```

**Um Statistiken der Aggregationstabelle abzurufen:**

```
http://localhost/vz/htdocs/middleware.php/capabilities/database.json
```
