### PR TITLE
Fix middleware undefined when loading groups form remote middleware

### DIFF
--- a/htdocs/frontend/javascripts/entity.js
+++ b/htdocs/frontend/javascripts/entity.js
@@ -47,7 +47,8 @@ Entity.prototype.parseJSON = function(json) {
 	// parse children
 	if (this.children) {
 		for (var i = 0; i < this.children.length; i++) {
-			this.children[i].middleware = this.middleware; // children inherit parent middleware		
+			// @todo check if setting middleware is really possible here
+			this.children[i].middleware = this.middleware; // children inherit parent middleware
 			this.children[i] = new Entity(this.children[i]);
 			this.children[i].parent = this;
 		}
@@ -78,6 +79,19 @@ Entity.prototype.parseJSON = function(json) {
 		this.color = vz.options.plot.colors[Entity.colors++ % vz.options.plot.colors.length];
 	}
 };
+
+/**
+ * Set middleware on entity and and inherit to children
+ * @var middleware url
+ */
+Entity.prototype.setMiddleware = function(middleware) {
+	this.middleware = middleware;
+	if (this.children) {
+		for (var i = 0; i < this.children.length; i++) {
+			this.children[i].middleware = this.middleware;
+		}
+	}
+}
 
 /**
  * Query middleware for details

--- a/htdocs/frontend/javascripts/wui.js
+++ b/htdocs/frontend/javascripts/wui.js
@@ -115,7 +115,9 @@ vz.wui.dialogs.init = function() {
 						success: function(json) {
 							var public = new Array;
 							json.entities.each(function(index, json) {
-								public.push(new Entity(json));
+								var entity = new Entity(json);
+								entity.setMiddleware(middleware.url);
+								public.push(entity);
 							});
 
 							public.sort(Entity.compare);


### PR DESCRIPTION
Behebt Fehler aus http://demo.volkszaehler.org/pipermail/volkszaehler-users/2013-December/003332.html

Ich habe ziemlich lange gebraucht den Originalcode zu verstehen. Letztlich versucht `Entity.prototype.parseJSON` Folgendes, insbesondere für die Verarbeitung von Gruppen:

```
// parse children
if (this.children) {
    for (var i = 0; i < this.children.length; i++) {
        this.children[i].middleware = this.middleware; // children inherit parent middleware
    }       
    this.children.sort(Entity.compare);
}
```

Das kann m.E. eigentlich nicht funktionieren da `this.middleware` zu diesem Zeitpunkt gar nicht definiert ist. `vz.load` nimmt daher immer die lokale Middleware, was seit der Möglichkeit "remote" Entities zu abonnieren nicht mehr funktioniert.
