### PR TITLE
Make all interpreters use timestamp at end of period

### DIFF
--- a/lib/Volkszaehler/Interpreter/MeterInterpreter.php
+++ b/lib/Volkszaehler/Interpreter/MeterInterpreter.php
@@ -79,7 +79,7 @@ class MeterInterpreter extends Interpreter {
 		foreach ($this->rows as $row) {
 			$delta = $row[0] - $ts_last;
 			$tuple = $callback(array(
-				(float) $ts_last, // timestamp of interval start
+				(float) ($ts_last = $row[0]), // timestamp of interval end
 				(float) ($row[1] * 3.6e9) / ($this->resolution * $delta), // doing df/dt
 				(int) $row[2] // num of rows
 			));
@@ -95,7 +95,6 @@ class MeterInterpreter extends Interpreter {
 			$this->pulseCount += $row[1];
 
 			$tuples[] = $tuple;
-			$ts_last = $row[0];
 		}
 
 		return $tuples;

--- a/lib/Volkszaehler/Interpreter/SensorInterpreter.php
+++ b/lib/Volkszaehler/Interpreter/SensorInterpreter.php
@@ -67,7 +67,7 @@ class SensorInterpreter extends Interpreter {
 		foreach ($this->rows as $row) {
 			$delta = $row[0] - $ts_last;
 			$tuple = $callback(array(
-				(float) $row[0],
+				(float) ($ts_last = $row[0]), // timestamp of interval end
 				(float) $row[1] / $row[2],
 				(int) $row[2]
 			));
@@ -83,7 +83,6 @@ class SensorInterpreter extends Interpreter {
 			$this->consumption += $tuple[1] * $delta;
 
 			$tuples[] = $tuple;
-			$ts_last = $row[0];
 		}
 
 		return $tuples;

--- a/test/Tests/DataCounterTest.php
+++ b/test/Tests/DataCounterTest.php
@@ -44,7 +44,7 @@ class DataCounterTest extends DataContext
 		$consumption = $this->getConsumption($fromValue, $toValue);
 		$average = $this->getAverage($from, $to, $consumption);
 
-		$result = array($from, $average);
+		$result = array($to, $average);
 		if ($count) $result[] = $count;
 
 		// timestamp of interval start

--- a/test/Tests/DataMeterTest.php
+++ b/test/Tests/DataMeterTest.php
@@ -44,7 +44,7 @@ class DataMeterTest extends DataContext
 		$consumption = $this->getConsumption($rawValue);
 		$average = $this->getAverage($from, $to, $consumption);
 
-		$result = array($from, $average);
+		$result = array($to, $average);
 		if ($count) $result[] = $count;
 
 		// timestamp of interval start


### PR DESCRIPTION
Vor diesem Fix gab es folgendes Verhalten:
- _Meter_: Anfang der Periode (d.h. das letzte Tupel war immer _älter_ als der letzte geschriebene Wert)
- _Counter_: Anfang der Periode (d.h. das letzte Tupel war immer _älter_ als der letzte geschriebene Wert oder anders gesagt es wurde der zum letzten Zählerstand gehörige Wert mit dem vorletzten Timestamp versehen)
- _Sensor_: Ende der Periode

Das Verhalten von Sensor ist jetzt Standard da intuitiver und für Zählerstände auch 'richtiger'.

Nebenbei wurden im Counter 2 Queries entfernt die nicht mehr notwendig sind.

Bitte um Review, Tests -> pass.
