### PR TITLE
Add export of multiple UUIDs

### DIFF
--- a/htdocs/frontend/javascripts/functions.js
+++ b/htdocs/frontend/javascripts/functions.js
@@ -39,17 +39,27 @@ var Exception = function(type, message, code) {
  */
 vz.getLink = function(format) {
 	var entities = new Array;
+	var middleware = '';
 	vz.entities.each(function(entity, parent) {
 		if (entity.active) {
-			entities.push(entity);
+			if (entities.length == 0) {
+				middleware = entity.middleware;
+			}
+			if (entity.middleware == middleware) {
+				entities.push(entity);
+			}
+			else {
+				// TODO add warning for entities from secondary MW
+			}
 		}
 	}, true); // recursive!
-	
-	var entity = entities[0]; // TODO handle other entities
-	
-	return entity.middleware + '/data/' + entity.uuid + '.' + format + '?' + $.param({
+
+	return entities[0].middleware + '/data.' + format + '?' + $.param({
 		from: Math.floor(vz.options.plot.xaxis.min),
-		to: Math.ceil(vz.options.plot.xaxis.max)
+		to: Math.ceil(vz.options.plot.xaxis.max),
+		uuid: entities.map(function(entity) {
+			return entity.uuid;
+		})
 	});
 };
 

--- a/lib/Volkszaehler/Interpreter/AggregatorInterpreter.php
+++ b/lib/Volkszaehler/Interpreter/AggregatorInterpreter.php
@@ -53,10 +53,11 @@ class AggregatorInterpreter extends Interpreter {
 	 * @param integer $from timestamp in ms since 1970
 	 * @param integer $to timestamp in ms since 1970
 	 * @todo handle channels in nested aggregators
+	 * @todo handle child entities of different units
 	 */
 	public function __construct(Model\Aggregator $aggregator, ORM\EntityManager $em, $from, $to, $tupleCount, $groupBy) {
 		$this->aggregator = $aggregator;
-		
+
 		foreach ($aggregator->getChildren() as $child) {
 			if ($child instanceof Model\Channel) {
 				$class = $child->getDefinition()->getInterpreter();

--- a/lib/Volkszaehler/View/JpGraph.php
+++ b/lib/Volkszaehler/View/JpGraph.php
@@ -128,9 +128,9 @@ class JpGraph extends View {
 		if ($data instanceof Interpreter\Interpreter) {
 			$this->addData($data);
 		}
-		elseif($data instanceof Interpreter\AggregatorInterpreter) {
-			foreach ($data->getChildrenInterpreter() as $childInterpreter) {
-				$this->add($childInterpreter);
+		elseif (is_array($data) && isset($data[0]) && $data[0] instanceof Interpreter\Interpreter) {
+			foreach ($data as $interpreter) {
+				$this->add($interpreter);
 			}
 		}
 		else {


### PR DESCRIPTION
Erlaubt den Export mehrer Kanäle als CVS und Grafik aus dem Frontend. 

Note: Um doppelte Daten zu vermeiden werden Gruppen im View nicht aufgelöst- das Frontend fügt die Child Entities bereits automatisch zum Request hinzu. Das könnte bei Gelegenheit nochmal konsistent gemacht werden so dass Gruppen immer aufgelöst werden.

Note 2: Die Nutzung des AggregatorControllers ist nicht ganz klar- die kritiklose min/max/avg Behandlung funktioniert nur in Sonderfällen...
