### PR TITLE
Add Travis CI continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,9 @@
 language: php
 
-# whitelist
-branches:
-    only:
-       - master-travis
-       - dev
-
 php:
     - "5.5"
-#    - "5.4"
-#    - "5.3"
+    - "5.4"
+    - "5.3"
 
 services:
     - mysql
@@ -21,8 +15,8 @@ env:
     - DB=sqlite
 
 notifications:
-# mail: "volkszaehler-dev@lists.volkszaehler.org"
-# irc: "chat.freenode.net/volkszaehler.org"
+    mail: "volkszaehler-dev@lists.volkszaehler.org"
+    irc: "chat.freenode.net#volkszaehler.org"
 
 before_install:
     - composer self-update


### PR DESCRIPTION
Travis CI integration is currently setup for my GitHub user; this can be changed from the Repository -> Settings -> Webhooks & Services -> Travis CI page.
