### PR TITLE
Beautify frontend display of entities table

### DIFF
--- a/htdocs/frontend/index.html
+++ b/htdocs/frontend/index.html
@@ -5,7 +5,7 @@
 <head>
 	<title>volkszaehler.org - web frontend</title>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-	
+
 	<link rel="shortcut icon" type="image/x-icon" href="../favicon.ico" />
 	<link rel="apple-touch-icon-precomposed" href="../favicon.ico" />
 	<!-- to support android versions newer than 2.3 -->
@@ -18,7 +18,7 @@
 	<script type="text/javascript" src="http://code.jquery.com/ui/1.10.1/jquery-ui.min.js"></script>
 	<script type="text/javascript" src="javascripts/jquery/jquery.treeTable.js"></script>
 	<script type="text/javascript" src="javascripts/jquery/jquery-extensions.js"></script>
-	
+
 	<!--[if IE]><script language="javascript" type="text/javascript" src="javascripts/flot/excanvas.min.js"></script><![endif]-->
 	<script type="text/javascript" src="javascripts/flot/jquery.flot.js"></script>
 	<script type="text/javascript" src="javascripts/flot/jquery.flot.crosshair.js"></script>
@@ -36,10 +36,10 @@
 			document.title = "Volkszaehler";
 		}
 	</script>
-	
+
 	<link rel="stylesheet" type="text/css" href="http://code.jquery.com/ui/1.10.1/themes/base/minified/jquery-ui.min.css" />
 	<link rel="stylesheet" type="text/css" href="stylesheets/jquery-treeTable.css" />
-	<link rel="stylesheet" type="text/css" href="stylesheets/jquery-ui-custom.css" />	
+	<link rel="stylesheet" type="text/css" href="stylesheets/jquery-ui-custom.css" />
 	<link rel="stylesheet" type="text/css" href="stylesheets/style.css" />
 </head>
 <body>
@@ -63,7 +63,7 @@
 	<div id="plot">
 		<div id="flot"></div>
 		<div id="overlay"></div>
-	</div>	
+	</div>
 
 <div id="accordion">
 	<div id="controls">
@@ -78,7 +78,7 @@
 		<button value="zoom-month">Monat</button>
 		<button value="zoom-year">Jahr</button>
 	</div>
-	
+
 		<h3><img src="images/table.png" alt="" /> Kanäle</h3>
 		<div id="entity-list">
 		<table>
@@ -88,13 +88,13 @@
 					<th></th>
 					<th>Titel</th>
 					<th>Typ</th>
-					<th>Min.</th>
-					<th>Max.</th>
-					<th>&empty;</th>
-					<th>aktuell</th>
-					<th>Verbrauch</th>
-					<th>Kosten</th>
-					<th>Aktion</th>
+					<th class="right">Min.</th>
+					<th class="right">Max.</th>
+					<th class="right">&empty;</th>
+					<th class="right">aktuell</th>
+					<th class="right">Verbrauch</th>
+					<th class="right">Kosten</th>
+					<th class="right">Aktion</th>
 				</tr>
 			</thead>
 			<tbody></tbody>

--- a/htdocs/frontend/javascripts/entity.js
+++ b/htdocs/frontend/javascripts/entity.js
@@ -1,6 +1,6 @@
 /**
  * Entity handling, parsing & validation
- * 
+ *
  * @author Justin Otherguy <justin@justinotherguy.org>
  * @author Steffen Vogel <info@steffenvogel.de>
  * @copyright Copyright (c) 2011, The volkszaehler.org project
@@ -9,16 +9,16 @@
  */
 /*
  * This file is part of volkzaehler.org
- * 
+ *
  * volkzaehler.org is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation, either version 3 of the License, or any later version.
- * 
+ *
  * volkzaehler.org is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
  * details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with
  * volkszaehler.org. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -52,15 +52,15 @@ Entity.prototype.parseJSON = function(json) {
 			this.children[i] = new Entity(this.children[i]);
 			this.children[i].parent = this;
 		}
-		
+
 		this.children.sort(Entity.compare);
 	}
 
-	// setting defaults	
+	// setting defaults
 	if (this.type !== undefined) {
 		this.definition = vz.capabilities.definitions.get('entities', this.type);
 		this.yaxis = ($.inArray(this.type, vz.options.y2axis) !== -1) ? 2 : 1;
-		
+
 		if (this.style === undefined) {
 			if (this.definition.style) {
 				this.style = this.definition.style;
@@ -107,7 +107,7 @@ Entity.prototype.loadDetails = function() {
 		success: function(json) {
 			this.parseJSON(json.entity);
 		}
-	});	
+	});
 };
 
 /**
@@ -146,7 +146,7 @@ Entity.prototype.loadData = function() {
 Entity.prototype.showDetails = function() {
 	var entity = this;
 	var dialog = $('<div>');
-	
+
 	dialog.addClass('details')
 	.append(this.getDOMDetails())
 	.dialog({
@@ -168,19 +168,19 @@ Entity.prototype.showDetails = function() {
 							entity.delete().done(function() {
 								entity.cookie = false;
 								vz.entities.saveCookie();
-							
+
 								vz.entities.each(function(it, parent) { // remove from tree
 									if (entity.uuid == it.uuid) {
 										var array = (parent) ? parent.children : vz.entities;
 										array.remove(it);
 									}
 								}, true);
-		
+
 								vz.entities.showTable();
 								vz.wui.drawPlot();
 								dialog.dialog('close');
 							});
-							
+
 							$(this).dialog('close');
 						},
 						'Abbrechen': function() {
@@ -200,38 +200,38 @@ Entity.prototype.showDetails = function() {
 Entity.prototype.getDOMDetails = function(edit) {
 	var table = $('<table><thead><tr><th>Eigenschaft</th><th>Wert</th></tr></thead></table>');
 	var data = $('<tbody>');
-	
+
 	// general properties
 	var general = ['title', 'type', 'uuid', 'middleware', 'color', 'style', 'active', 'cookie'];
 	var sections = ['required', 'optional'];
-	
+
 	general.each(function(index, property) {
 		var definition = vz.capabilities.definitions.get('properties', property);
 		var title = (definition) ? definition.translation[vz.options.language] : property;
 		var value = this[property];
-		
+
 		switch(property) {
 			case 'type':
 				var title = 'Typ';
 				var icon = this.definition.icon ? $('<img>').
 						attr('src', 'images/types/' + this.definition.icon)
-						.css('margin-right', 4) 
+						.css('margin-right', 4)
 					: null;
 				var value = $('<span>')
 					.text(this.definition.translation[vz.options.language])
 					.prepend(icon ? icon : null);
 				break;
-			
+
 			case 'middleware':
 				var title = 'Middleware';
 				var value = '<a href="' + this.middleware + '/capabilities.json">' + this.middleware + '</a>';
 				break;
-			
+
 			case 'uuid':
 				var title = 'UUID';
 				var value = '<a href="' + this.middleware + '/entity/' + this.uuid + '.json">' + this.uuid + '</a>';
 				break;
-	
+
 			case 'color':
 				var value = $('<span>')
 					.text(this.color)
@@ -239,7 +239,7 @@ Entity.prototype.getDOMDetails = function(edit) {
 					.css('padding-left', 5)
 					.css('padding-right', 5);
 				break;
-				
+
 			case 'cookie':
 				var title = 'Cookie';
 				value = '<img src="images/' + ((this.cookie) ? 'tick' : 'cross') + '.png" alt="' + ((value) ? 'ja' : 'nein') + '" />';
@@ -255,7 +255,7 @@ Entity.prototype.getDOMDetails = function(edit) {
 				}
 				break;
 		}
-		
+
 		data.append($('<tr>')
 			.addClass('property')
 			.addClass('general')
@@ -269,18 +269,18 @@ Entity.prototype.getDOMDetails = function(edit) {
 			)
 		);
 	}, this);
-	
+
 	sections.each(function(index, section) {
 		this.definition[section].each(function(index, property) {
 			if (this.hasOwnProperty(property) && !general.contains(property)) {
 				var definition = vz.capabilities.definitions.get('properties', property);
 				var title = definition.translation[vz.options.language];
 				var value = this[property];
-		
+
 				if (definition.type == 'boolean') {
 					value = '<img src="images/' + ((value) ? 'tick' : 'cross') + '.png" alt="' + ((value) ? 'ja' : 'nein') + '" />';
 				}
-					
+
 				if (property == 'cost') {
 					value = Number(value * 1000 * 100).toFixed(2) + ' ct/k' + this.definition.unit + 'h'; // ct per kWh
 				}
@@ -333,12 +333,12 @@ Entity.prototype.getDOMRow = function(parent) {
 			)
 		)
 		.append($('<td>').text(this.definition.translation[vz.options.language])) // channel type
-		.append($('<td>').addClass('min'))		// min
-		.append($('<td>').addClass('max'))		// max
-		.append($('<td>').addClass('average'))		// avg
-		.append($('<td>').addClass('last'))		// last value
-		.append($('<td>').addClass('consumption'))	// consumption
-		.append($('<td>').addClass('cost'))		// costs
+		.append($('<td>').addClass('right min'))		// min
+		.append($('<td>').addClass('right max'))		// max
+		.append($('<td>').addClass('right average'))		// avg
+		.append($('<td>').addClass('right last'))		// last value
+		.append($('<td>').addClass('right consumption'))	// consumption
+		.append($('<td>').addClass('right cost'))		// costs
 		.append($('<td>')				// operations
 			.addClass('ops')
 			.append($('<input>')
@@ -351,8 +351,8 @@ Entity.prototype.getDOMRow = function(parent) {
 			)
 		)
 		.data('entity', this);
-	
-	if (this.cookie) {		
+
+	if (this.cookie) {
 		$('td.ops', row).prepend($('<input>')
 			.attr('type', 'image')
 			.attr('src', 'images/delete.png')
@@ -365,16 +365,16 @@ Entity.prototype.getDOMRow = function(parent) {
 			})
 		);
 	}
-		
+
 	return row;
 };
 
 Entity.prototype.activate = function(state, parent, recursive) {
 	this.active = state;
 	var queue = new Array;
-	
+
 	$('#entity-' + this.uuid + ((parent) ? '.child-of-entity-' + parent.uuid : '') + ' input[type=checkbox]').attr('checked', state);
-					
+
 	if (this.active) {
 		queue.push(this.loadData()); // reload data
 	}
@@ -382,7 +382,7 @@ Entity.prototype.activate = function(state, parent, recursive) {
 		this.data = undefined; // clear data
 		this.updateDOMRow();
 	}
-	
+
 	if (recursive) {
 		this.each(function(child, parent) {
 			queue.push(child.activate(state, parent, true));
@@ -406,7 +406,7 @@ Entity.prototype.updateDOMRow = function() {
 	if (this.data && this.data.rows > 0) { // update statistics if data available
 		var delta = this.data.to - this.data.from;
 		var year = 365*24*60*60*1000;
-	
+
 		if (this.data.min)
 			$('.min', row)
 			.text(vz.wui.formatNumber(this.data.min[1], true) + this.definition.unit)
@@ -426,7 +426,7 @@ Entity.prototype.updateDOMRow = function() {
 			$('.consumption', row)
 			.text(vz.wui.formatNumber(this.data.consumption, true) + this.definition.unit + 'h')
 			.attr('title', vz.wui.formatNumber(this.data.consumption * (year/delta), true) + this.definition.unit + 'h' + '/Jahr');
-		
+
 		if (this.cost) {
 			$('.cost', row)
 				.text(vz.wui.formatNumber(this.cost * this.data.consumption) + ' €')
@@ -455,7 +455,7 @@ Entity.prototype.addChild = function(child) {
 	if (this.definition.model != 'Volkszaehler\\Model\\Aggregator') {
 		throw new Exception('EntityException', 'Entity is not an Aggregator');
 	}
-	
+
 	return vz.load({
 		controller: 'group',
 		identifier: this.uuid,
@@ -490,14 +490,14 @@ Entity.prototype.removeChild = function(child) {
 
 /**
  * Calls the callback function for the entity and all nested children
- * 
+ *
  * @param cb callback function
  */
 Entity.prototype.each = function(cb, recursive) {
 	if (this.children) {
 		for (var i = 0; i < this.children.length; i++) {
 			cb(this.children[i], this);
-			
+
 			if (recursive && this.children[i] !== undefined) {
 				this.children[i].each(cb, true); // call recursive
 			}

--- a/htdocs/frontend/javascripts/wui.js
+++ b/htdocs/frontend/javascripts/wui.js
@@ -1,6 +1,6 @@
 /**
  * Javascript functions for the frontend
- * 
+ *
  * @author Florian Ziegler <fz@f10-home.de>
  * @author Justin Otherguy <justin@justinotherguy.org>
  * @author Steffen Vogel <info@steffenvogel.de>
@@ -10,16 +10,16 @@
  */
 /*
  * This file is part of volkzaehler.org
- * 
+ *
  * volkzaehler.org is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation, either version 3 of the License, or any later version.
- * 
+ *
  * volkzaehler.org is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
  * details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with
  * volkszaehler.org. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -29,7 +29,7 @@
  */
 vz.wui.init = function() {
 	vz.options.tuples = Math.round($('#flot').width() / 3);
-	
+
 	// initialize dropdown accordion
 	$('#accordion h3').click(function() {
 		$(this).next().toggle('fast', function() {
@@ -41,16 +41,16 @@ vz.wui.init = function() {
 				break;
 			}
 		});
-		
+
 		return false;
 	}).next().hide();
 	$('#entity-list').show(); // open entity list by default
-	
+
 	// buttons
 	$('button, input[type=button],[type=image],[type=submit]').button();
 	$('button[name=options-save]').click(vz.options.saveCookies);
 	$('button[name=entity-add]').click(this.dialogs.init);
-	
+
 	$('#export select').change(function(event) {
 		switch ($(this).val()) {
 			case 'permalink':
@@ -61,15 +61,15 @@ vz.wui.init = function() {
 			case 'xml':
 				window.location = vz.getLink($(this).val());
 				break;
-				
+
 		}
 		$('#export option[value=default]').attr('selected', true);
 	});
-	
+
 	// bind plot actions
 	$('#controls button').click(this.handleControls);
 	$('#controls').buttonset();
-	
+
 	// auto refresh
 	if (vz.options.refresh) {
 		$('#refresh').prop('checked', true);
@@ -85,7 +85,7 @@ vz.wui.init = function() {
 			vz.wui.clearTimeout();
 		}
 	});
-	
+
 	// toggle all channels
 	$('#entity-toggle').click(function() {
 		vz.entities.each(function(entity, parent) {
@@ -122,7 +122,7 @@ vz.wui.dialogs.init = function() {
 
 							public.sort(Entity.compare);
 							vz.middleware[idx].public = public;
-					
+
 							if (idx == 0) {
 								populateEntities(vz.middleware[idx]);
 							}
@@ -132,7 +132,7 @@ vz.wui.dialogs.init = function() {
 			}
 		}
 	});
-	
+
 	// show available entity types
 	vz.capabilities.definitions.entities.each(function(index, def) {
 		$('#entity-create select[name=type]').append(
@@ -154,7 +154,7 @@ vz.wui.dialogs.init = function() {
 	$('#entity-create-middleware').val(vz.options.localMiddleware);
 	$('#entity-subscribe-cookie').attr('checked', 'checked');
 	$('#entity-public-cookie').attr('checked', 'checked');
-	
+
 	// actions
 	$('#entity-public-middleware').change(function() {
 		var title = $('#entity-public-middleware option:selected').text();
@@ -172,11 +172,11 @@ vz.wui.dialogs.init = function() {
 				uuid: $('#entity-subscribe-uuid').val(),
 				cookie: Boolean($('#entity-subscribe-cookie').attr('checked'))
 			});
-			
+
 			if (middleware = $('#entity-subscribe-middleware').val()) {
 				entity.middleware = middleware;
 			}
-			
+
 			entity.loadDetails().done(function() {
 				vz.entities.push(entity);
 				vz.entities.saveCookie();
@@ -191,14 +191,14 @@ vz.wui.dialogs.init = function() {
 			$('#entity-add').dialog('close');
 		}
 	});
-	
+
 	$('#entity-public input[type=button]').click(function() {
 		var entity = $('#entity-public-entity option:selected').data('entity');
-	
+
 		try {
 			entity.cookie = Boolean($('#entity-public-cookie').attr('checked'));
 			entity.middleware = $('#entity-public-middleware option:selected').val();
-			
+
 			vz.entities.push(entity);
 			vz.entities.saveCookie();
 			vz.entities.showTable();
@@ -234,22 +234,22 @@ vz.wui.dialogs.init = function() {
 						.append(
 							$('<td>').text(propdef.translation[vz.options.language])
 						);
-					
+
 					switch (propdef.type) {
 						case 'float':
 						case 'integer':
 						case 'string':
 							cntrl = $('<input>').attr("type", "text");
 							break;
-							
+
 						case 'text':
 							cntrl = $('<textarea>');
 							break;
-					
+
 						case 'boolean':
 							cntrl = $('<input>').attr("type", "checkbox");
 							break;
-						
+
 						case 'multiple':
 							cntrl = $('<select>').attr("Size", "1");
 							propdef.options.each(function(optindex, optdef) {
@@ -259,7 +259,7 @@ vz.wui.dialogs.init = function() {
 							});
 							break;
 					}
-					
+
 					if (cntrl != null) {
 						row.addClass(className);
 						cntrl.attr("name", propdef.name);
@@ -270,20 +270,20 @@ vz.wui.dialogs.init = function() {
 			});
 		});
 	}
-	
+
 	$('#entity-create select').change(function() {
 		$('#entity-create form table .required').remove();
 		$('#entity-create form table .optional').remove();
-		
+
 		addProperties(vz.capabilities.definitions.entities[$(this)[0].selectedIndex].required, "required");
 		addProperties(vz.capabilities.definitions.entities[$(this)[0].selectedIndex].optional, "optional");
 	});
 	$('#entity-create select').change();
-	
+
 	$('#entity-create form').submit(function() {
 		var def = $('select[name=type] option:selected', this).data('definition');
 		var properties = {};
-		
+
 		$(this).serializeArray().each(function(index, value) {
 			if (value.value != '') {
 				properties[value.name] = value.value;
@@ -297,7 +297,7 @@ vz.wui.dialogs.init = function() {
 			type: 'POST',
 			success: function(json) {
 				var entity = new Entity(json.entity);
-				
+
 				try {
 					entity.cookie = Boolean($('#entity-create-cookie').attr('checked'));
 					entity.middleware = $('#entity-create-middleware').val();
@@ -310,15 +310,15 @@ vz.wui.dialogs.init = function() {
 				catch (e) {
 					vz.wui.dialogs.exception(e);
 				}
-				finally {	
+				finally {
 					$('#entity-add').dialog('close');
 				}
 			}
 		});
-		
+
 		return false;
 	});
-	
+
 	// update event handler after lazy loading
 	$('button[name=entity-add]').unbind('click', this.init);
 	$('button[name=entity-add]').click(function() {
@@ -340,16 +340,16 @@ vz.wui.zoom = function(from, to) {
 	}
 
 	vz.wui.tmaxnow = (vz.options.plot.xaxis.max >= (now - 1000));
-	
+
 	if (vz.options.plot.xaxis.min < 0) {
 		vz.options.plot.xaxis.min = 0;
 	}
-	
+
 	vz.options.plot.yaxes.each(function(i) {
 		vz.options.plot.yaxes[i].max = null; // autoscaling
 		vz.options.plot.yaxes[i].min = 0; // fixed to 0
 	});
-	
+
 	vz.entities.loadData().done(vz.wui.drawPlot);
 };
 
@@ -393,7 +393,7 @@ vz.wui.updateLegend = function() {
 	vz.wui.updateLegendTimeout = null;
 
 	var pos = vz.wui.latestPosition;
-	
+
         var axes = vz.plot.getAxes();
         if (pos.x < axes.xaxis.min || pos.x > axes.xaxis.max ||
 	    pos.y < axes.yaxis.min || pos.y > axes.yaxis.max)
@@ -533,10 +533,10 @@ vz.wui.setTimeout = function() {
 		window.clearTimeout(vz.wui.timeout);
 		vz.wui.timeout = null;
 	}
-	
+
 	var t = Math.max((vz.options.plot.xaxis.max - vz.options.plot.xaxis.min) / vz.options.tuples, vz.options.minTimeout);
 	vz.wui.timeout = window.setTimeout(vz.wui.refresh, t);
-	
+
 	$('#refresh-time').html('(' + Math.round(t / 1000) + ' s)');
 };
 
@@ -545,7 +545,7 @@ vz.wui.setTimeout = function() {
  */
 vz.wui.clearTimeout = function(text) {
 	$('#refresh-time').html(text || '');
-	
+
 	var rc = window.clearTimeout(vz.wui.timeout);
 	vz.wui.timeout = null;
 	return rc;
@@ -563,14 +563,18 @@ vz.wui.clearTimeout = function(text) {
 vz.wui.formatNumber = function(number, prefix) {
 	var siPrefixes = ['k', 'M', 'G', 'T'];
 	var siIndex = 0;
-	
+
 	while (prefix && Math.abs(number) > 1000 && siIndex < siPrefixes.length-1) {
 		number /= 1000;
 		siIndex++;
 	}
-	
-	number = Math.round(number * Math.pow(10, vz.options.precision)) / Math.pow(10, vz.options.precision); // rounding
-	
+
+    // avoid infinities/NaN
+	if (number > 0) {
+		var precision = Math.max(0, vz.options.precision - Math.floor(Math.log(number)/Math.LN10));
+		number = Math.round(number * Math.pow(10, precision)) / Math.pow(10, precision); // rounding
+	}
+
 	if (prefix) {
 		number += (siIndex > 0) ? ' ' + siPrefixes[siIndex-1] : ' ';
 	}
@@ -581,10 +585,10 @@ vz.wui.formatNumber = function(number, prefix) {
 vz.wui.updateHeadline = function() {
 	var delta = vz.options.plot.xaxis.max - vz.options.plot.xaxis.min;
 	var format = '%B %d. %b %y';
-	
+
 	if (delta < 3*24*3600*1000) format += ' %h:%M'; // under 3 days
 	if (delta < 5*60*1000) format += ':%S'; // under 5 minutes
-	
+
 	var from = $.plot.formatDate(new Date(vz.options.plot.xaxis.min), format, vz.options.monthNames, vz.options.dayNames, true);
 	var to = $.plot.formatDate(new Date(vz.options.plot.xaxis.max), format, vz.options.monthNames, vz.options.dayNames, true);
 	$('#title').html(from + ' - ' + to);
@@ -629,11 +633,11 @@ vz.wui.drawPlot = function () {
 
 			entity.index = index;
 			++index;
-			
+
 			series.push(serie);
 		}
 	}, true);
-	
+
 	if (series.length == 0) {
 		$('#overlay').html('<img src="images/empty.png" alt="no data..." /><p>nothing to plot...</p>');
 		series.push({}); // add empty dataset to show axes
@@ -641,7 +645,7 @@ vz.wui.drawPlot = function () {
 	else {
 		$('#overlay').empty();
 	}
-	
+
 	var flot = $('#flot');
 	vz.plot = $.plot(flot, series, vz.options.plot);
 
@@ -650,7 +654,7 @@ vz.wui.drawPlot = function () {
 		var pos = 'position:absolute; left:40px; top:5px;';
 		var legend = $('<div id="legend" style="'+pos+'width:'+flot.width()+'"> </div>');
 		flot.append(legend);
-	
+
 		vz.plot.getOptions().legend.show = true;
 		vz.plot.getOptions().legend.container = legend; // $('#legend');
 		vz.plot.setupGrid();

--- a/htdocs/frontend/stylesheets/style.css
+++ b/htdocs/frontend/stylesheets/style.css
@@ -13,7 +13,7 @@ table {
 
 tr th {
 	border-bottom: 2px solid grey;
-	
+
 	text-align: left;
 	font-size: 0.9em;
 }
@@ -137,7 +137,7 @@ select.icons option {
 	padding: 10px;
 }
 
-.ops {
+.right, .ops {
 	text-align: right;
 }
 


### PR DESCRIPTION
Update entity-list to right-align numeric columns (header & body rows).
Adjust value rounding to reduce precision by 1 for each power of 10. I.e. with precision=2 it will format numbers like
- 1.111 -> 1.11
- 11.111 -> 11.1
- 111.111 -> 111
- 1111.111 -> 1.11 k

My editor removes trailing spaces from all lines. If this is not desired I need to provide updated patch. If this is desired I could add .editorconfig as well.
