### PR TITLE
Upgrade jQuery to 1.11

### DIFF
--- a/htdocs/frontend/index.html
+++ b/htdocs/frontend/index.html
@@ -13,13 +13,19 @@
 	<meta name="apple-mobile-web-app-capable" content="yes" />
 	<meta name="apple-mobile-web-app-status-bar-style" content="black" />
 
+	<!-- CSS before JS -->
+	<link rel="stylesheet" type="text/css" href="http://code.jquery.com/ui/1.10.1/themes/base/minified/jquery-ui.min.css" />
+	<link rel="stylesheet" type="text/css" href="stylesheets/jquery-treeTable.css" />
+	<link rel="stylesheet" type="text/css" href="stylesheets/jquery-ui-custom.css" />
+	<link rel="stylesheet" type="text/css" href="stylesheets/style.css" />
+
 	<!-- jQuery -->
-	<script type="text/javascript" src="http://code.jquery.com/jquery-1.9.1.min.js"></script>
-	<script type="text/javascript" src="http://code.jquery.com/ui/1.10.1/jquery-ui.min.js"></script>
+	<script type="text/javascript" src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
+	<script type="text/javascript" src="http://code.jquery.com/ui/1.10.4/jquery-ui.min.js"></script>
 	<script type="text/javascript" src="javascripts/jquery/jquery.treeTable.js"></script>
 	<script type="text/javascript" src="javascripts/jquery/jquery-extensions.js"></script>
 
-	<!--[if IE]><script language="javascript" type="text/javascript" src="javascripts/flot/excanvas.min.js"></script><![endif]-->
+	<!--[if lte IE 8]><script language="javascript" type="text/javascript" src="javascripts/flot/excanvas.min.js"></script><![endif]-->
 	<script type="text/javascript" src="javascripts/flot/jquery.flot.js"></script>
 	<script type="text/javascript" src="javascripts/flot/jquery.flot.crosshair.js"></script>
 	<script type="text/javascript" src="javascripts/flot/jquery.flot.selection.js"></script>
@@ -36,11 +42,6 @@
 			document.title = "Volkszaehler";
 		}
 	</script>
-
-	<link rel="stylesheet" type="text/css" href="http://code.jquery.com/ui/1.10.1/themes/base/minified/jquery-ui.min.css" />
-	<link rel="stylesheet" type="text/css" href="stylesheets/jquery-treeTable.css" />
-	<link rel="stylesheet" type="text/css" href="stylesheets/jquery-ui-custom.css" />
-	<link rel="stylesheet" type="text/css" href="stylesheets/style.css" />
 </head>
 <body>
 <div id="header"></div>


### PR DESCRIPTION
Not heavily tested, should give minor performance improvement:
- Upgrade jQuery to 1.11
- Upgrade jQuery-UI to 1.10.4
- Use excanvas only for IE < 9
- Move css before js to load in parallel
