### PR TITLE
Fix activating children in entities table

### DIFF
--- a/htdocs/frontend/javascripts/entity.js
+++ b/htdocs/frontend/javascripts/entity.js
@@ -407,12 +407,12 @@ Entity.prototype.getDOMRow = function(parent) {
 			)
 		)
 		.append($('<td>').text(this.definition.translation[vz.options.language])) // channel type
-		.append($('<td>').addClass('right min'))		// min
-		.append($('<td>').addClass('right max'))		// max
-		.append($('<td>').addClass('right average'))		// avg
-		.append($('<td>').addClass('right last'))		// last value
-		.append($('<td>').addClass('right consumption'))	// consumption
-		.append($('<td>').addClass('right cost'))		// costs
+		.append($('<td>').addClass('min'))		// min
+		.append($('<td>').addClass('max'))		// max
+		.append($('<td>').addClass('average'))		// avg
+		.append($('<td>').addClass('last'))		// last value
+		.append($('<td>').addClass('consumption'))	// consumption
+		.append($('<td>').addClass('cost'))		// costs
 		.append($('<td>')				// operations
 			.addClass('ops')
 			.append($('<input>')
@@ -447,7 +447,7 @@ Entity.prototype.activate = function(state, parent, recursive) {
 	this.active = state;
 	var queue = new Array;
 
-	$('#entity-' + this.uuid + ((parent) ? '.child-of-entity-' + parent.uuid : '') + ' input[type=checkbox]').attr('checked', state);
+	$('#entity-' + this.uuid + ((parent) ? '.child-of-entity-' + parent.uuid : '') + ' input[type=checkbox]').prop('checked', state);
 
 	if (this.active) {
 		queue.push(this.loadData()); // reload data


### PR DESCRIPTION
Clicking group checkbox deactivates children. Clicking again should activate again but misses to set checkbox. This is the fix.
