### PR TITLE
Fix activation of children in entities table

### DIFF
--- a/htdocs/frontend/javascripts/entity.js
+++ b/htdocs/frontend/javascripts/entity.js
@@ -447,7 +447,7 @@ Entity.prototype.activate = function(state, parent, recursive) {
 	this.active = state;
 	var queue = new Array;
 
-	$('#entity-' + this.uuid + ((parent) ? '.child-of-entity-' + parent.uuid : '') + ' input[type=checkbox]').attr('checked', state);
+	$('#entity-' + this.uuid + ((parent) ? '.child-of-entity-' + parent.uuid : '') + ' input[type=checkbox]').prop('checked', state);
 
 	if (this.active) {
 		queue.push(this.loadData()); // reload data


### PR DESCRIPTION
Clicking group checkbox deactivates children. Clicking again should activate again but misses to set checkbox. This fix sets the checkboxes as well.
