### PR TITLE
Allow hiding properties from dialogs

### DIFF
--- a/htdocs/frontend/javascripts/options.js
+++ b/htdocs/frontend/javascripts/options.js
@@ -43,6 +43,7 @@ vz.options = {
 	lineWidthDefault: 2,
 	lineWidthSelected: 4,
 	speedupFactor: 2,   // higher values give higher speedup but can produce chunky display
+	hiddenProperties: ['link', 'tolerance', 'local'] // hide less commonly used properties
 };
 
 vz.options.plot = {

--- a/htdocs/frontend/javascripts/wui.js
+++ b/htdocs/frontend/javascripts/wui.js
@@ -126,6 +126,13 @@ vz.wui.init = function() {
 // show available properties for selected type
 vz.wui.dialogs.addProperties = function(container, proplist, className, entity) {
 	proplist.each(function(index, def) {
+
+		// hide properties from blacklist
+		var val = (entity && typeof entity[def] !== undefined) ? entity[def] : null;
+		if (val == null && vz.options.hiddenProperties.indexOf(def) >= 0) {
+			return; // hide less commonly used properties
+		}
+
 		vz.capabilities.definitions.properties.each(function(propindex, propdef) {
 			if (def == propdef.name) {
 				var cntrl = null;
@@ -161,9 +168,8 @@ vz.wui.dialogs.addProperties = function(container, proplist, className, entity) 
 				}
 
 				// editing?
-				if (entity && cntrl != null) {
+				if (entity && cntrl !== null) {
 					// set current value
-					var val = (entity && typeof entity[def] != 'undefined') ? entity[def] : null;
 					switch (propdef.type) {
 						case 'float':
 						case 'integer':
@@ -222,6 +228,8 @@ vz.wui.dialogs.addProperties = function(container, proplist, className, entity) 
 					row.append($('<td>').append(cntrl));
 					container.append(row);
 				}
+
+				return false;
 			}
 		});
 	});
@@ -734,7 +742,7 @@ vz.wui.drawPlot = function () {
 					show: (entity.style == 'lines' || entity.style == 'steps'),
 					steps: (entity.style == 'steps'),
 					lineWidth: (index == vz.wui.selectedChannel ? vz.options.lineWidthSelected : vz.options.lineWidthDefault),
-					fill: (typeof entity.fillstyle != 'undefined') ? entity.fillstyle : false
+					fill: (typeof entity.fillstyle !== undefined) ? entity.fillstyle : false
 				},
 				points: {
 					show: (entity.style == 'points')


### PR DESCRIPTION
While Volkszaehler provides more and more functionality (e.g. custom definition of fillstyle, axis assignment etc) the UI becomes overloaded. This pr hides some rarely- used properties and makes this behavior customizable. If an entity with hidden property is being edited, the property will be available for editing.
