### PR TITLE
Fix jshint warnings

### DIFF
--- a/htdocs/frontend/javascripts/entities.js
+++ b/htdocs/frontend/javascripts/entities.js
@@ -30,7 +30,7 @@
  */
 vz.entities.saveCookie = function() {
 	var expires = new Date(2038, 0, 1); // some days before y2k38 problem
-	var arr = new Array;
+	var arr = [];
 
 	this.each(function(entity) {
 		if (entity.cookie === true) {
@@ -69,14 +69,14 @@ vz.entities.loadData = function() {
 	var middlewares = {};
 	this.each(function(entity) {
 		if (entity.active && entity.definition && entity.definition.model == 'Volkszaehler\\Model\\Channel') {
-			if (middlewares[entity.middleware] == undefined) {
-				middlewares[entity.middleware] = new Array();
+			if (middlewares[entity.middleware] === undefined) {
+				middlewares[entity.middleware] = [];
 			}
 			middlewares[entity.middleware].push(entity.uuid);
 		}
 	}, true); // recursive!
 
-	var queue = new Array;
+	var queue = [];
 	$.each(middlewares, function(middleware, uuids) {
 		queue.push(vz.entities.loadMultipleData(middleware, uuids));
 	});
@@ -124,7 +124,7 @@ vz.entities.loadMultipleData = function(middleware, uuids) {
 			}, true);
 		}
 	});
-}
+};
 
 /**
  * Overwritten each iterator to iterate recursively throug all entities
@@ -137,7 +137,7 @@ vz.entities.each = function(cb, recursive) {
 			this[i].each(cb, true);
 		}
 	}
-}
+};
 
 /**
  * Create nested entity list
@@ -194,8 +194,8 @@ vz.entities.showTable = function() {
 					width: 400,
 					buttons: {
 						'Verschieben': function() {
+							var queue = [];
 							try {
-								var queue = new Array;
 								if (to) {
 									queue.push(to.addChild(child)); // add to new aggregator
 								} else { // add to root
@@ -218,7 +218,7 @@ vz.entities.showTable = function() {
 								vz.wui.dialogs.exception(e);
 							} finally {
 								$.when.apply($, queue).done(function() { // wait for middleware
-									var q = new Array;
+									var q = [];
 									if (from)
 										q.push(from.loadDetails());
 									if (to)

--- a/htdocs/frontend/javascripts/entity.js
+++ b/htdocs/frontend/javascripts/entity.js
@@ -90,7 +90,7 @@ Entity.prototype.setMiddleware = function(middleware) {
 	this.each(function(child, parent) {
 		child.middleware = middleware;
 	}, true); // recursive!
-}
+};
 
 /**
  * Query middleware for details
@@ -123,7 +123,7 @@ Entity.prototype.updateData = function(data) {
 	}
 
 	this.updateDOMRow();
-}
+};
 
 /**
  * Load data for current view from middleware
@@ -217,7 +217,7 @@ Entity.prototype.showDetails = function() {
 							var properties = {};
 
 							$(this).find('form').serializeArrayWithCheckBoxes().each(function(index, value) {
-								if (value.value != '' || entity[value.name]) {
+								if (value.value !== '' || entity[value.name]) {
 									properties[value.name] = value.value;
 								}
 							});
@@ -277,39 +277,39 @@ Entity.prototype.getDOMDetails = function(edit) {
 
 		switch (property) {
 			case 'type':
-				var title = 'Typ';
+				title = 'Typ';
 				var icon = this.definition.icon ? $('<img>').
 						attr('src', 'images/types/' + this.definition.icon)
 						.css('margin-right', 4)
 					: null;
-				var value = $('<span>')
+				value = $('<span>')
 					.text(this.definition.translation[vz.options.language])
 					.prepend(icon ? icon : null);
 				break;
 
 			case 'middleware':
-				var title = 'Middleware';
-				var value = '<a href="' + this.middleware + '/capabilities.json">' + this.middleware + '</a>';
+				title = 'Middleware';
+				value = '<a href="' + this.middleware + '/capabilities.json">' + this.middleware + '</a>';
 				break;
 
 			case 'uuid':
-				var title = 'UUID';
-				var value = '<a href="' + this.middleware + '/entity/' + this.uuid + '.json">' + this.uuid + '</a>';
+				title = 'UUID';
+				value = '<a href="' + this.middleware + '/entity/' + this.uuid + '.json">' + this.uuid + '</a>';
 				break;
 
 			case 'cookie':
-				var title = 'Cookie';
+				title = 'Cookie';
 				value = '<img src="images/' + ((this.cookie) ? 'tick' : 'cross') + '.png" alt="' + ((value) ? 'ja' : 'nein') + '" />';
 				break;
 
 			case 'active':
-				var value = '<img src="images/' + ((this.active) ? 'tick' : 'cross') + '.png" alt="' + ((this.active) ? 'ja' : 'nein') + '" />';
+				value = '<img src="images/' + ((this.active) ? 'tick' : 'cross') + '.png" alt="' + ((this.active) ? 'ja' : 'nein') + '" />';
 				break;
 			case 'style':
 				switch (this.style) {
-					case 'lines': var value = 'Linien'; break;
-					case 'steps': var value = 'Stufen'; break;
-					case 'points': var value = 'Punkte'; break;
+					case 'lines': value = 'Linien'; break;
+					case 'steps': value = 'Stufen'; break;
+					case 'points': value = 'Punkte'; break;
 				}
 				break;
 		}
@@ -350,7 +350,7 @@ Entity.prototype.getDOMDetails = function(edit) {
 						break;
 
 					case 'color':
-						var value = $('<span>')
+						value = $('<span>')
 							.text(this.color)
 							.css('background-color', this.color)
 							.css('padding-left', 5)
@@ -359,9 +359,9 @@ Entity.prototype.getDOMDetails = function(edit) {
 
 					case 'style':
 						switch (this.style) {
-							case 'lines': var value = 'Linien'; break;
-							case 'steps': var value = 'Stufen'; break;
-							case 'points': var value = 'Punkte'; break;
+							case 'lines': value = 'Linien'; break;
+							case 'steps': value = 'Stufen'; break;
+							case 'points': value = 'Punkte'; break;
 						}
 						break;
 				}
@@ -452,7 +452,7 @@ Entity.prototype.getDOMRow = function(parent) {
 
 Entity.prototype.activate = function(state, parent, recursive) {
 	this.active = state;
-	var queue = new Array;
+	var queue = [];
 
 	$('#entity-' + this.uuid + ((parent) ? '.child-of-entity-' + parent.uuid : '') + ' input[type=checkbox]').prop('checked', state);
 
@@ -471,7 +471,7 @@ Entity.prototype.activate = function(state, parent, recursive) {
 	}
 
 	return $.when.apply($, queue);
-}
+};
 
 Entity.prototype.updateDOMRow = function() {
 	var row = $('#entity-' + this.uuid);
@@ -529,7 +529,7 @@ Entity.prototype.delete = function() {
 		url: this.middleware,
 		type: 'DELETE'
 	});
-}
+};
 
 /**
  * Add entity as child
@@ -548,7 +548,7 @@ Entity.prototype.addChild = function(child) {
 			uuid: child.uuid
 		}
 	});
-}
+};
 
 /**
  * Remove entity from children

--- a/htdocs/frontend/javascripts/functions.js
+++ b/htdocs/frontend/javascripts/functions.js
@@ -38,11 +38,11 @@ var Exception = function(type, message, code) {
  * @return string url
  */
 vz.getLink = function(format) {
-	var entities = new Array;
+	var entities = [];
 	var middleware = '';
 	vz.entities.each(function(entity, parent) {
 		if (entity.active) {
-			if (entities.length == 0) {
+			if (entities.length === 0) {
 				middleware = entity.middleware;
 			}
 			if (entity.middleware == middleware) {
@@ -69,7 +69,7 @@ vz.getLink = function(format) {
  * @return string url
  */
 vz.getPermalink = function() {
-	var uuids = new Array;
+	var uuids = [];
 	vz.entities.each(function(entity, parent) {
 		if (entity.active) {
 			if (entity.middleware != vz.options.localMiddleware) {
@@ -102,20 +102,21 @@ vz.load = function(args) {
  		},
 		error: function(xhr) {
 			try {
+				var msg;
 				if (xhr.getResponseHeader('Content-type') == 'application/json') {
 					var json = $.parseJSON(xhr.responseText);
 
 					if (json.exception) {
-						var msg = xhr.requestUrl + ':<br/><br/>' + json.exception.message;
+						msg = xhr.requestUrl + ':<br/><br/>' + json.exception.message;
 						throw new Exception(json.exception.type, msg, (json.exception.code) ? json.exception.code : xhr.status);
 					}
 				}
 				else {
-					var msg = xhr.requestUrl + ':<br/><br/>Unknown middleware response';
+					msg = xhr.requestUrl + ':<br/><br/>Unknown middleware response';
 					if (xhr.responseText) {
 						msg += '<br/><br/>' + $(xhr.responseText).text().substring(0,300);
 					}
-					throw new Exception(xhr.statusText, msg, xhr.status)
+					throw new Exception(xhr.statusText, msg, xhr.status);
 				}
 			}
 			catch (e) {
@@ -170,7 +171,7 @@ vz.load = function(args) {
  */
 vz.parseUrlParams = function() {
 	var vars = $.getUrlParams();
-	var entities = new Array;
+	var entities = [];
 	var save = false;
 
 	for (var key in vars) {
@@ -196,7 +197,7 @@ vz.parseUrlParams = function() {
 	}
 
 	entities.each(function(index, identifier) {
-		var identifier = identifier.split('@');
+		identifier = identifier.split('@');
 		var uuid = identifier[0];
 		var middleware = (identifier.length > 1) ? identifier[1] : vz.options.localMiddleware;
 
@@ -248,35 +249,40 @@ vz.capabilities.definitions.get = function(section, name) {
 };
 
 /**
- * Deferred script loading
- */
-jQuery.cachedScript = function(url, options) {
-	// Allow user to set any option except for dataType, cache, and url
-	options = $.extend(options || {}, {
-		dataType: "script",
-		cache: true,
-		url: url
-	});
-	// Use $.ajax() since it is more flexible than $.getScript
-	// Return the jqXHR object so we can chain callbacks
-	return jQuery.ajax( options );
-};
-
-/**
- * Serialize form including unchecked checkboxes
- * http://stackoverflow.com/questions/3029870/jquery-serialize-does-not-register-checkboxes
- *
- * @todo make off value and default selection configurable
+ * jQuery extensions
  */
 (function($) {
+
+	/**
+	 * Deferred script loading
+	 */
+	$.cachedScript = function(url, options) {
+		// Allow user to set any option except for dataType, cache, and url
+		options = $.extend(options || {}, {
+			dataType: "script",
+			cache: true,
+			url: url
+		});
+		// Use $.ajax() since it is more flexible than $.getScript
+		// Return the jqXHR object so we can chain callbacks
+		return $.ajax(options);
+	};
+
+	/**
+	 * Serialize form including unchecked checkboxes
+	 * http://stackoverflow.com/questions/3029870/jquery-serialize-does-not-register-checkboxes
+	 *
+	 * @todo make off value and default selection configurable
+	 */
 	$.fn.serializeArrayWithCheckBoxes = function() {
 		// serialize form the non-checkbox fields
 		return $(this).serializeArray()
 		// add values for unchecked checkbox fields
 		.concat(
 			$(this).find("input[type=checkbox]:not(:checked)").map(function() {
-				return { "name": this.name, "value": "0" }
+				return { "name": this.name, "value": "0" };
 			}).get()
 		);
-	}
+	};
+
 })(jQuery);

--- a/htdocs/frontend/javascripts/helper.js
+++ b/htdocs/frontend/javascripts/helper.js
@@ -1,8 +1,8 @@
 /**
  * Some functions and prototypes which make our life easier
- * 
+ *
  * not volkszaehler.org related
- * 
+ *
  * @author Florian Ziegler <fz@f10-home.de>
  * @author Justin Otherguy <justin@justinotherguy.org>
  * @author Steffen Vogel <info@steffenvogel.de>
@@ -12,16 +12,16 @@
  */
 /*
  * This file is part of volkzaehler.org
- * 
+ *
  * volkzaehler.org is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation, either version 3 of the License, or any later version.
- * 
+ *
  * volkzaehler.org is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
  * details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with
  * volkszaehler.org. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -54,20 +54,20 @@ Array.prototype.contains = function(n) {
 
 Array.prototype.clear = function() {
 	this.length = 0;
-}
+};
 
 Array.prototype.unique = function() {
-	var r = new Array;
+	var r = [];
 	this.each(function(key, value) {
 		if (!r.contains(value)) {
 			r.push(value);
 		}
 	});
 	return r;
-}
+};
 
 Array.prototype.last = function() {
 	if (this.length > 0) {
 		return this[this.length-1];
 	}
-}
+};

--- a/htdocs/frontend/javascripts/init.js
+++ b/htdocs/frontend/javascripts/init.js
@@ -32,8 +32,8 @@
  * we dont want to pollute the global namespace
  */
 var vz = {
-	entities: new Array,	// entity properties + data
-	middleware: new Array,	// array of all known middlewares
+	entities: [],	// entity properties + data
+	middleware: [],	// array of all known middlewares
 	wui: {			// web user interface
 		dialogs: { },
 		timeout: null
@@ -63,11 +63,11 @@ $(document).ready(function() {
 				vz.plot.draw();
 		}
 	});
-	
+
 	window.onerror = function(errorMsg, url, lineNumber) {
 		vz.wui.dialogs.error('Javascript Runtime Error', errorMsg);
 	};
-	
+
 	// initialize variables
 	vz.middleware.push({ // default middleware
 		url: vz.options.localMiddleware,
@@ -85,17 +85,17 @@ $(document).ready(function() {
 			/* capabilities: { } */
 		});
 	});
-	
+
 	// TODO make language/translation dependent (vz.options.language)
 	vz.options.plot.xaxis.monthNames = vz.options.monthNames;
 	vz.options.plot.xaxis.dayNames = vz.options.dayNames;
-	
+
 	// start loading cookies/url params
 	vz.entities.loadCookie(); // load uuids from cookie
 	vz.options.loadCookies(); // load options from cookie
-	
+
 	// set x axis limits _after_ loading options cookie
-	vz.options.plot.xaxis.max = new Date().getTime(); 
+	vz.options.plot.xaxis.max = new Date().getTime();
 	vz.options.plot.xaxis.min = vz.options.plot.xaxis.max - vz.options.interval;
 
 	// parse additional url params (new uuid etc e.g. for permalink) after loading defaults
@@ -104,31 +104,31 @@ $(document).ready(function() {
 	// initialize user interface
 	vz.wui.init();
 	vz.wui.initEvents();
-	
+
 	// chaining ajax request with jquery deferred object
 	vz.capabilities.load().done(function() {
 		if (vz.capabilities.formats.contains('png')) {
 			$('#export option[value=png]').removeAttr('disabled');
 		}
-		
-		var queue = new Array;
+
+		var queue = [];
 		vz.entities.each(function(entity) {
 			var p = $.when(entity.loadDetails()).then(
 				function(x) { return {result:x, resolved:true}; },
-				function(x) { return (new $.Deferred).resolve({result:x, resolved:false}); }
+				function(x) { return (new $.Deferred()).resolve({result:x, resolved:false}); }
 			);
 			queue.push(p);
 		}, true);
-		
+
 		var cb = function(x) {
-			if (vz.entities.length == 0) {
+			if (vz.entities.length === 0) {
 				vz.wui.dialogs.init();
 			}
-		
+
 			vz.entities.showTable();
 			vz.entities.loadData().done(vz.wui.drawPlot);
 		};
 		$.when.apply($, queue).done(cb);
 	});
-});	
+});
 

--- a/htdocs/frontend/javascripts/property.js
+++ b/htdocs/frontend/javascripts/property.js
@@ -1,6 +1,6 @@
 /**
  * Property handling & validation
- * 
+ *
  * @author Florian Ziegler <fz@f10-home.de>
  * @author Justin Otherguy <justin@justinotherguy.org>
  * @author Steffen Vogel <info@steffenvogel.de>
@@ -10,16 +10,16 @@
  */
 /*
  * This file is part of volkzaehler.org
- * 
+ *
  * volkzaehler.org is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation, either version 3 of the License, or any later version.
- * 
+ *
  * volkzaehler.org is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
  * details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with
  * volkszaehler.org. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -44,30 +44,30 @@ Property.prototype.validate = function(value) {
 			// TODO check pattern
 			// TODO check string length
 			return true;
-			
+
 		case 'float':
 			// TODO check format
 			// TODO check min/max
 			return true;
-			
+
 		case 'integer':
 			// TODO check format
 			// TODO check min/max
 			return true;
-			
+
 		case 'boolean':
 			return value == '1' || value == '';
-			
+
 		case 'multiple':
 			return this.options.contains(value);
-			
+
 		default:
 			throw new Exception('EntityException', 'Unknown property');
 	}
 };
 
 /**
- * 
+ *
  * @todo implement/test
  */
 Property.prototype.getInput = function(value) {
@@ -79,19 +79,19 @@ Property.prototype.getInput = function(value) {
 				.attr('type', 'text')
 				.attr('name=', this.name)
 				.attr('maxlength', (property.type == 'string') ? this.max : 0);
-			
+
 		case 'text':
 			return $('<textarea>')
 				.attr('name', this.name);
-			
+
 		case 'boolean':
 			return $('<input>')
 				.attr('type', 'checkbox')
 				.attr('name', this.name)
 				.attr('checked', true);
-			
+
 		case 'multiple':
-			var dom = $('<select>').attr('name', property.name)
+			var dom = $('<select>').attr('name', property.name);
 			property.options.each(function(index, option) {
 				dom.append($('<option>')
 					.value(option)
@@ -99,7 +99,7 @@ Property.prototype.getInput = function(value) {
 				);
 			});
 			return dom;
-	
+
 		default:
 			throw new Exception('PropertyException', 'Unknown property');
 	}

--- a/htdocs/frontend/javascripts/wui.js
+++ b/htdocs/frontend/javascripts/wui.js
@@ -129,7 +129,7 @@ vz.wui.dialogs.addProperties = function(container, proplist, className, entity) 
 
 		// hide properties from blacklist
 		var val = (entity && typeof entity[def] !== undefined) ? entity[def] : null;
-		if (val == null && vz.options.hiddenProperties.indexOf(def) >= 0) {
+		if (val === null && vz.options.hiddenProperties.indexOf(def) >= 0) {
 			return; // hide less commonly used properties
 		}
 
@@ -222,7 +222,7 @@ vz.wui.dialogs.addProperties = function(container, proplist, className, entity) 
 						break;
 				}
 
-				if (cntrl != null) {
+				if (cntrl !== null) {
 					row.addClass(className);
 					cntrl.attr("name", propdef.name);
 					row.append($('<td>').append(cntrl));
@@ -233,7 +233,7 @@ vz.wui.dialogs.addProperties = function(container, proplist, className, entity) 
 			}
 		});
 	});
-}
+};
 
 /**
  * Initialize dialogs
@@ -254,7 +254,7 @@ vz.wui.dialogs.init = function() {
 						controller: 'entity',
 						url: middleware.url,
 						success: function(json) {
-							var public = new Array;
+							var public = [];
 							json.entities.each(function(index, json) {
 								var entity = new Entity(json);
 								entity.setMiddleware(middleware.url);
@@ -264,7 +264,7 @@ vz.wui.dialogs.init = function() {
 							public.sort(Entity.compare);
 							vz.middleware[idx].public = public;
 
-							if (idx == 0) {
+							if (idx === 0) {
 								populateEntities(vz.middleware[idx]);
 							}
 						}
@@ -314,7 +314,7 @@ vz.wui.dialogs.init = function() {
 				cookie: Boolean($('#entity-subscribe-cookie').prop('checked'))
 			});
 
-			if (middleware = $('#entity-subscribe-middleware').val()) {
+			if (middleware == $('#entity-subscribe-middleware').val()) {
 				entity.setMiddleware(middleware);
 			}
 
@@ -380,7 +380,7 @@ vz.wui.dialogs.init = function() {
 
 		// serializeArray instead of serializeArrayWithCheckBoxes is sufficient as non-active checkboxes don't need to create properties
 		$(this).serializeArray().each(function(index, value) {
-			if (value.value != '') {
+			if (value.value !== '') {
 				properties[value.name] = value.value;
 			}
 		});
@@ -481,7 +481,7 @@ vz.wui.initEvents = function() {
 			vz.wui.latestPosition = pos;
 			if (!vz.wui.updateLegendTimeout)
 				vz.wui.updateLegendTimeout = setTimeout(vz.wui.updateLegend, 50);
-		})
+		});
 };
 
 vz.wui.updateLegend = function() {
@@ -522,15 +522,11 @@ vz.wui.updateLegend = function() {
 		if (y == null) {
 			vz.wui.legend.eq(i).text(series.title);
 		} else {
-			function fmt(x) {
-				return (x > 9 ? x : '0'+x);
-			}
 			var d = new Date(pos.x);
-			var timestr = fmt(d.getHours()) + ':' + fmt(d.getMinutes()) + ':' + fmt(d.getSeconds());
-			vz.wui.legend.eq(i).text(series.title + ": " + timestr + " - " + y.toFixed(1) + " " + series.unit);
+			vz.wui.legend.eq(i).text(series.title + ": " + $.plot.formatDate(d, '%H:%M:%S') + " - " + y.toFixed(1) + " " + series.unit);
 		}
 	}
-}
+};
 
 /**
  * Move & zoom in the plotting area
@@ -624,7 +620,7 @@ vz.wui.refresh = function() {
  */
 vz.wui.setTimeout = function() {
 	// clear an already set timeout
-	if (vz.wui.timeout != null) {
+	if (vz.wui.timeout !== null) {
 		window.clearTimeout(vz.wui.timeout);
 		vz.wui.timeout = null;
 	}
@@ -689,7 +685,7 @@ vz.wui.formatConsumptionUnit = function(unit) {
 		unit += 'h';
 	}
 	return unit;
-}
+};
 
 vz.wui.updateHeadline = function() {
 	var delta = vz.options.plot.xaxis.max - vz.options.plot.xaxis.min;
@@ -701,7 +697,7 @@ vz.wui.updateHeadline = function() {
 	var from = $.plot.formatDate(new Date(vz.options.plot.xaxis.min), format, vz.options.monthNames, vz.options.dayNames, true);
 	var to = $.plot.formatDate(new Date(vz.options.plot.xaxis.max), format, vz.options.monthNames, vz.options.dayNames, true);
 	$('#title').html(from + ' - ' + to);
-}
+};
 
 /**
  * Draws plot to container
@@ -710,24 +706,24 @@ vz.wui.drawPlot = function () {
 	vz.options.interval = vz.options.plot.xaxis.max - vz.options.plot.xaxis.min;
 	vz.wui.updateHeadline();
 
-	var series = new Array;
+	var series = [];
 	var index = 0;
 	vz.entities.each(function(entity) {
 		if (entity.active && entity.definition && entity.definition.model == 'Volkszaehler\\Model\\Channel' &&
 		    entity.data && entity.data.tuples && entity.data.tuples.length > 0) {
-			var tuples = entity.data.tuples;
+			var i, tuples = entity.data.tuples;
 
 			// mangle data for "steps" curves by shifting one ts left ("step-before")
 			if (tuples && tuples.length > 0 && entity.style == "steps") {
 				tuples.unshift([entity.data.from, 1, 1]); // add new first ts
-				for (var i=0; i<tuples.length-1; i++) {
+				for (i=0; i<tuples.length-1; i++) {
 					tuples[i][1] = tuples[i+1][1];
 				}
 			}
 
 			// remove number of datapoints from each tuple to avoid flot fill error
 			if (tuples && tuples.length > 0 && entity.fillstyle) {
-				for (var i=0; i<tuples.length; i++) {
+				for (i=0; i<tuples.length; i++) {
 					delete tuples[i][2];
 				}
 			}
@@ -757,7 +753,7 @@ vz.wui.drawPlot = function () {
 		}
 	}, true);
 
-	if (series.length == 0) {
+	if (series.length === 0) {
 		$('#overlay').html('<img src="images/empty.png" alt="no data..." /><p>nothing to plot...</p>');
 		series.push({}); // add empty dataset to show axes
 	}


### PR DESCRIPTION
Only the simple fixes to reduce risk, remaining cases to be analyzed:

```
C:\vz>gulp jshint
[gulp] Using gulpfile C:\vz\gulpfile.js
[gulp] Starting 'jshint'...
[gulp] Finished 'jshint' after 303 ms
C:\vz\htdocs\frontend\javascripts\property.js: line 59, col 42, Use '===' to compare with ''.

1 error
C:\vz\htdocs\frontend\javascripts\wui.js: line 517, col 20, Use '===' to compare with 'null'.
C:\vz\htdocs\frontend\javascripts\wui.js: line 517, col 34, Use '===' to compare with 'null'.
C:\vz\htdocs\frontend\javascripts\wui.js: line 522, col 15, Use '===' to compare with 'null'.
```
