### PR TITLE
Fix issue introduced with b39d8f70

### DIFF
--- a/htdocs/frontend/javascripts/wui.js
+++ b/htdocs/frontend/javascripts/wui.js
@@ -315,9 +315,7 @@ vz.wui.dialogs.init = function() {
 				cookie: Boolean($('#entity-subscribe-cookie').prop('checked'))
 			});
 
-			if (middleware == $('#entity-subscribe-middleware').val()) {
-				entity.setMiddleware(middleware);
-			}
+			entity.setMiddleware($('#entity-subscribe-middleware').val());
 
 			entity.loadDetails().done(function() {
 				vz.entities.push(entity);


### PR DESCRIPTION
Klasse Fehler- Originalcode (meiner) missverständlich, mittels jshint den "Fehler" behoben. Dann tat der Code das wonach er aussah- nämlich nix vernünftiges. Jetzt sollte es passen.
