### PR TITLE
Add support for highlighting entity selection in chart

### DIFF
--- a/htdocs/frontend/javascripts/entities.js
+++ b/htdocs/frontend/javascripts/entities.js
@@ -247,8 +247,17 @@ vz.entities.showTable = function() {
 
 	// make visible that a row is clicked
 	$('#entity-list table tbody tr').mousedown(function() {
+		var entity = $(this).data('entity');
+		var selected = $('tr.selected').data('entity');
+
 		$('tr.selected').removeClass('selected'); // deselect currently selected rows
-		$(this).addClass('selected');
+		vz.wui.selectedChannel = null;
+
+		if (entity !== selected) {
+			$(this).addClass('selected');
+			vz.wui.selectedChannel = entity.index;
+		}
+		vz.wui.drawPlot();
 	});
 
 	// make sure row is selected when span is clicked

--- a/htdocs/frontend/javascripts/wui.js
+++ b/htdocs/frontend/javascripts/wui.js
@@ -755,8 +755,8 @@ vz.wui.drawPlot = function () {
 				yaxis: entity.assignedYaxis
 			};
 
-			entity.index = index;
-			++index;
+			// use this index for setting vz.wui.selectedChannel
+			entity.index = index++;
 
 			series.push(serie);
 		}


### PR DESCRIPTION
This feature has been party present in the code already but was not active due to missing population of `vz.wui.selectedChannel`. To make this nice from usability perspective `mousedown` does now allow selection as well as de-selection of entities (on second click).
