### PR TITLE
Add support for data series with gaps

### DIFF
--- a/htdocs/frontend/index.html
+++ b/htdocs/frontend/index.html
@@ -32,6 +32,7 @@
 	<script type="text/javascript" src="javascripts/flot/jquery.flot.time.js"></script>
 	<script type="text/javascript" src="javascripts/flot/jquery.flot.canvas.js"></script>
 	<script type="text/javascript" src="javascripts/flot/jquery.flot.axislabels.js"></script>
+	<script type="text/javascript" src="javascripts/flot/jquery.flot.xgap.js"></script>
 
 	<script type="text/javascript" src="javascripts/helper.js"></script>
 	<script type="text/javascript" src="javascripts/init.js"></script>

--- a/htdocs/frontend/javascripts/flot/jquery.flot.xgap.js
+++ b/htdocs/frontend/javascripts/flot/jquery.flot.xgap.js
@@ -1,0 +1,128 @@
+/**
+ * Flot plugin for adding gaps to the line in a line graph when a certain x threashold has been reached.
+ *
+ * Usage:
+ *
+ * To configure this plugin, values must be added to two areas.
+ * 
+ * The first is in the global x-axis options:
+ * xaxis: {
+ *   insertGaps: true,  // enable or disable this plugin
+ *   gapColor: rgba(100,100,100,0.2) // the color to use for gaps - undefined is no indication
+ * }
+ *
+ * The second is in the series object for a set of data.
+ * var series1 = {
+ *   data: [ ... ],
+ *   label: 'Series 1',
+ *   xGapThresh: 300 // A value of 300 here indicates that a x-gap > 300 will insert a gap
+ * }
+ *
+ * Enjoy!
+ *
+ * @author Joel Oughton
+ */
+(function($){
+    function init(plot){
+        var _options = plot.getOptions();
+
+        function checkXgapEnabled(plot, options){
+        
+            if (options.xaxis.insertGaps) {
+                plot.hooks.processRawData.push(insertGaps);
+            }
+        }
+
+        /**
+         * Indicates line gaps by drawing a vertical rectangle in its place
+         */
+        function indicateGaps(plot, ctx) {
+            if (!_options.xaxis.gapColor) return;
+
+            var gaps = _options.xaxis.gaps, p2c = plot.getAxes().xaxis.p2c, 
+            offset = plot.getPlotOffset(), container = plot.getPlaceholder(),
+            drawWidth = container.width() - offset.left - offset.right, plotHeight = container.height();
+            
+            if (!gaps) return;
+
+            ctx.fillStyle = _options.xaxis.gapColor;
+
+            // draw the gaps
+            $.each(gaps, function(index, gap) {
+                var x1, x2;
+
+                x1 = p2c(gap.start);
+                x2 = p2c(gap.end);
+
+                // keep the bar within the graph range
+                if (x1 < 0) x1 = 0;
+                if (x2 < 0) x2 = 0;
+                if (x1 > drawWidth) x1 = drawWidth;
+                if (x2 > drawWidth) x2 = drawWidth;
+
+                // only draw if need be
+                if (x1 == x2) return;
+                
+                ctx.fillRect(x1 + offset.left, offset.top, x2 - x1, plotHeight - offset.bottom - offset.top);
+            });
+        }
+        
+        function insertGaps(plot, series, data, datapoints){
+            if (series.xGapThresh) {
+                var prev = -1;
+                var holes = [];
+                var offset = 0;
+                var bin = series.xGapThresh;
+                var gaps = [];
+                
+                // loop through the datapoints
+                for (var i = 0; i < data.length; i++) {
+                    // check if the data has already been processed
+                    if (data[i][0] == null) return;
+
+                    // find a hole in the data
+                    if (prev != -1 &&
+                    data[i][0] - prev > bin) {
+                        // carefully add each hole found
+                        holes.push(i + offset);
+                        offset++;
+                    }
+                    prev = data[i][0];
+                }
+                
+                // output all the holes as nulls
+                // this breaks the line in flot
+                for (var i = 0; i < holes.length; i++) {
+                    data.splice(holes[i], 0, [null, null]);
+                }
+                
+                // build up array of gaps
+                for (var i = 0; i < data.length; i++) {
+                    if (data[i][0] != null) continue;
+
+                    if (data[i - 1] && data[i + 1]) {
+                        gaps.push({ start: data[i - 1][0], end: data[i + 1][0] });
+                    }
+                }
+                _options.xaxis.gaps = gaps;
+            }
+        }
+        
+        plot.hooks.processOptions.push(checkXgapEnabled);
+        plot.hooks.draw.push(indicateGaps);
+    }
+    
+    var options = {
+        xaxis: {
+            insertGaps: false,  // enable or disable this plugin
+            gapColor: undefined // the color to use for gaps - undefined is no indication
+        }
+    };
+    
+    $.plot.plugins.push({
+        init: init,
+        options: options,
+        name: "xgapthreshold",
+        version: "0.3"
+    });
+})(jQuery);

--- a/htdocs/frontend/javascripts/wui.js
+++ b/htdocs/frontend/javascripts/wui.js
@@ -720,7 +720,7 @@ vz.wui.drawPlot = function () {
 	vz.entities.each(function(entity) {
 		if (entity.active && entity.definition && entity.definition.model == 'Volkszaehler\\Model\\Channel' &&
 				entity.data && entity.data.tuples && entity.data.tuples.length > 0) {
-			var i, tuples = entity.data.tuples;
+			var i, tuples = entity.data.tuples, maxTuples = 0;
 
 			// mangle data for "steps" curves by shifting one ts left ("step-before")
 			if (entity.style == "steps") {
@@ -731,8 +731,9 @@ vz.wui.drawPlot = function () {
 			}
 
 			// remove number of datapoints from each tuple to avoid flot fill error
-			if (entity.fillstyle) {
+			if (entity.fillstyle || entity.gap) {
 				for (i=0; i<tuples.length; i++) {
+					maxTuples = Math.max(maxTuples, tuples[i][2]);
 					delete tuples[i][2];
 				}
 			}
@@ -754,6 +755,13 @@ vz.wui.drawPlot = function () {
 				},
 				yaxis: entity.assignedYaxis
 			};
+
+			// disable interpolation when data has gaps
+			if (entity.gap) {
+				var minGapWidth = (entity.data.to - entity.data.from) / tuples.length;
+				serie.xGapThresh = Math.max(entity.gap * 1000 * maxTuples, minGapWidth);
+				vz.options.plot.xaxis.insertGaps = true;
+			}
 
 			// use this index for setting vz.wui.selectedChannel
 			entity.index = index++;

--- a/lib/Volkszaehler/Definition/EntityDefinition.json
+++ b/lib/Volkszaehler/Definition/EntityDefinition.json
@@ -98,12 +98,11 @@
 	},
 	{
 		"name"			: "voltage",
-		"optional"		: ["tolerance", "cost", "local"],
+		"optional"		: ["tolerance", "local", "gap"],
 		"icon"			: "bolt.png",
 		"unit"			: "V",
 		"interpreter"		: "Volkszaehler\\Interpreter\\SensorInterpreter",
 		"model"			: "Volkszaehler\\Model\\Channel",
-		"hasConsumption"	: false,
 		"translation"		: {
 			"de" : "Spannungssensor",
 			"en" : "Voltage Meter",
@@ -199,7 +198,7 @@
 	},
 	{
 		"name"			: "temperature",
-		"optional"		: ["tolerance", "local"],
+		"optional"		: ["tolerance", "local", "gap"],
 		"icon"			: "thermometer.png",
 		"unit"			: "°C",
 		"interpreter"		: "Volkszaehler\\Interpreter\\SensorInterpreter",
@@ -212,7 +211,7 @@
 	},
 	{
 		"name"			: "pressure",
-		"optional"		: ["tolerance", "local"],
+		"optional"		: ["tolerance", "local", "gap"],
 		"icon"			: "cloud.png",
 		"unit"			: "hPa",
 		"interpreter"		: "Volkszaehler\\Interpreter\\SensorInterpreter",
@@ -225,7 +224,7 @@
 	},
 	{
 		"name"			: "humidity",
-		"optional"		: ["tolerance", "local"],
+		"optional"		: ["tolerance", "local", "gap"],
 		"icon"			: "rain.png",
 		"unit"			: "%",
 		"interpreter"		: "Volkszaehler\\Interpreter\\SensorInterpreter",
@@ -238,7 +237,7 @@
 	},
 	{
 		"name"			: "windspeed",
-		"optional"		: ["tolerance", "local"],
+		"optional"		: ["tolerance", "local", "gap"],
 		"icon"			: "propeller.png",
 		"unit"			: "km/h",
 		"interpreter"		: "Volkszaehler\\Interpreter\\SensorInterpreter",
@@ -251,7 +250,7 @@
 	},
 	{
 		"name"			: "radiation",
-		"optional"		: ["tolerance", "local", "resolution"],
+		"optional"		: ["tolerance", "local", "gap", "resolution"],
 		"icon"			: "radioactivity.png",
 		"unit"			: "μSv",
 		"interpreter"		: "Volkszaehler\\Interpreter\\SensorInterpreter",
@@ -264,7 +263,7 @@
 	},
 	{
 		"name"			: "luminosity",
-		"optional"		: ["tolerance", "local"],
+		"optional"		: ["tolerance", "local", "gap"],
 		"icon"			: "sun.png",
 		"unit"			: "cd",
 		"interpreter"		: "Volkszaehler\\Interpreter\\SensorInterpreter",
@@ -292,7 +291,7 @@
 	},
 	{
 		"name"			: "valve",
-		"optional"		: ["tolerance", "local"],
+		"optional"		: ["tolerance", "local", "gap"],
 		"icon"			: "pipe.png",
 		"unit"			: "%",
 		"interpreter"		: "Volkszaehler\\Interpreter\\SensorInterpreter",

--- a/lib/Volkszaehler/Definition/PropertyDefinition.json
+++ b/lib/Volkszaehler/Definition/PropertyDefinition.json
@@ -414,5 +414,14 @@
 			"de" : "Lokale Adresse",
 			"en" : "Local Address"
 		}
+	},
+	{
+		"name"			: "gap",
+		"type"			: "integer",
+		"min"			: 0,
+		"translation"		: {
+			"de" : "Lücke",
+			"en" : "Gap"
+		}
 	}
 ]


### PR DESCRIPTION
This request allows to force the frontend to stop interpolating when data points are missing. A new optional property `gap` indicates the minimum number of seconds the frontend should consider when displaying a time series as interrupted. 
Useful for data that is e.g. only available during operating hours (like solar systems power or voltage). Not available for entities with `hasConsumption=true`.

Example:

![unbenannt](https://cloud.githubusercontent.com/assets/184815/3095255/85a102e6-e5c5-11e3-880a-2e91988ba51f.png)
