### PR TITLE
Hide uncommon properties in edit dialog, too

### DIFF
--- a/htdocs/frontend/javascripts/wui.js
+++ b/htdocs/frontend/javascripts/wui.js
@@ -130,7 +130,7 @@ vz.wui.dialogs.addProperties = function(container, proplist, className, entity) 
 
 		// hide properties from blacklist
 		var val = (entity && typeof entity[def] !== undefined) ? entity[def] : null;
-		if (val === null && vz.options.hiddenProperties.indexOf(def) >= 0) {
+		if ((typeof val === 'undefined' || val === null) && vz.options.hiddenProperties.indexOf(def) >= 0) {
 			return; // hide less commonly used properties
 		}
 


### PR DESCRIPTION
As result, the vz.options.hiddenProperties will effectively remove the named properties from the ui unless they are already defined for an existing channel.
