### PR TITLE
Allow parsing of text timestamps for debugging purposes (e.g. &ts=today)

### DIFF
--- a/lib/Volkszaehler/Controller/DataController.php
+++ b/lib/Volkszaehler/Controller/DataController.php
@@ -25,6 +25,7 @@ namespace Volkszaehler\Controller;
 
 use Volkszaehler\Model;
 use Volkszaehler\Util;
+use Volkszaehler\Interpreter\Interpreter;
 
 /**
  * Data controller
@@ -105,6 +106,9 @@ class DataController extends Controller {
 
 			if (is_null($timestamp)) {
 				$timestamp = (double) round(microtime(TRUE) * 1000);
+			}
+			else {
+				$timestamp = Interpreter::parseDateTimeString($timestamp);
 			}
 
 			if (is_null($value)) {

--- a/lib/Volkszaehler/Interpreter/Interpreter.php
+++ b/lib/Volkszaehler/Interpreter/Interpreter.php
@@ -243,7 +243,7 @@ abstract class Interpreter {
 	 * @param float $now in ms since 1970
 	 * @return float
 	 */
-	protected static function parseDateTimeString($string) {
+	public static function parseDateTimeString($string) {
 		if (ctype_digit((string)$string)) { // handling as ms timestamp
 			return (float) $string;
 		}


### PR DESCRIPTION
Note entirely beautiful but working without much change.
