### PR TITLE
Allow display of short type names in entity table

### DIFF
--- a/htdocs/frontend/javascripts/entity.js
+++ b/htdocs/frontend/javascripts/entity.js
@@ -497,6 +497,10 @@ Entity.prototype.getDOMDetails = function(edit) {
  * Get DOM for list of entities
  */
 Entity.prototype.getDOMRow = function(parent) {
+	// full or shortened type name
+	var type = this.definition.translation[vz.options.language];
+	if (vz.options.shortenLongTypes) type = type.replace(/\s*\(.+?\)/, '');
+
 	var row =  $('<tr>')
 		.addClass((parent) ? 'child-of-entity-' + parent.uuid : '')
 		.addClass((this.definition.model == 'Volkszaehler\\Model\\Aggregator') ? 'aggregator' : 'channel')
@@ -529,7 +533,7 @@ Entity.prototype.getDOMRow = function(parent) {
 				)
 			)
 		)
-		.append($('<td>').text(this.definition.translation[vz.options.language])) // channel type
+		.append($('<td>').text(type)) // channel type
 		.append($('<td>').addClass('min'))		// min
 		.append($('<td>').addClass('max'))		// max
 		.append($('<td>').addClass('average'))		// avg

--- a/htdocs/frontend/javascripts/options.js
+++ b/htdocs/frontend/javascripts/options.js
@@ -29,6 +29,7 @@ vz.options = {
 	precision: 2,		// TODO update from middleware capabilities?
 	tuples: null,		// automatically determined by plot size
 	refresh: false,
+	shortenLongTypes: false, // show shorter type names in table
 	minTimeout: 2000,	// minimum refresh time in ms
 	interval: 24*60*60*1000, // 1 day default time interval to show
 	localMiddleware: '../middleware.php',


### PR DESCRIPTION
Removes the part in () from the type naje, e.g. `El. Energy (Zaehlerstand)` becomes `El. Energy`.