### PR TITLE
Legend extended to show date not only H:M:S

### DIFF
--- a/htdocs/frontend/javascripts/wui.js
+++ b/htdocs/frontend/javascripts/wui.js
@@ -526,7 +526,7 @@ vz.wui.updateLegend = function() {
 			if ((jetzt - d) > (1000 * 60 * 60 * 24)) {
 				vz.wui.legend.eq(i).text(series.title + ": " + $.plot.formatDate(d, '%d.%m.%y - %H:%M') + " - " + y.toFixed(1) + $
 			} else {
-                        	vz.wui.legend.eq(i).text(series.title + ": " + $.plot.formatDate(d, '%H:%M:%S') + " - " + y.toFixed(1) + " " + $
+				vz.wui.legend.eq(i).text(series.title + ": " + $.plot.formatDate(d, '%H:%M:%S') + " - " + y.toFixed(1) + " " + $
                         }
 		}
 	}

--- a/htdocs/frontend/javascripts/wui.js
+++ b/htdocs/frontend/javascripts/wui.js
@@ -525,11 +525,7 @@ vz.wui.updateLegend = function() {
 			var delta = vz.options.plot.xaxis.max - vz.options.plot.xaxis.min;
 			var format;
 			// Interval more than 1 day ?
-			if(delta > 1*24*3600*1000) { 
-				format = '%d.%m.%y - %H:%M';
-			} else {
-				format = '%H:%M:%S';
-			}
+			var format = (delta > 1*24*3600*1000) ? '%d.%m.%y - %H:%M' : '%H:%M:%S';
 			vz.wui.legend.eq(i).text(series.title + ": " + $.plot.formatDate(d,format) + " - " + y.toFixed(0) + " " + series.unit);
 		}
 	}

--- a/htdocs/frontend/javascripts/wui.js
+++ b/htdocs/frontend/javascripts/wui.js
@@ -527,7 +527,7 @@ vz.wui.updateLegend = function() {
 				vz.wui.legend.eq(i).text(series.title + ": " + $.plot.formatDate(d, '%d.%m.%y - %H:%M') + " - " + y.toFixed(1) + $
 			} else {
 				vz.wui.legend.eq(i).text(series.title + ": " + $.plot.formatDate(d, '%H:%M:%S') + " - " + y.toFixed(1) + " " + $
-                        }
+			}
 		}
 	}
 

--- a/htdocs/frontend/javascripts/wui.js
+++ b/htdocs/frontend/javascripts/wui.js
@@ -522,7 +522,12 @@ vz.wui.updateLegend = function() {
 		} else {
 			// use plot wrapper instead of `new Date()` for timezone support
 			var d = $.plot.dateGenerator(pos.x, vz.options.plot.xaxis);
-			vz.wui.legend.eq(i).text(series.title + ": " + $.plot.formatDate(d, '%H:%M:%S') + " - " + y.toFixed(1) + " " + series.unit);
+			var jetzt = $.plot.dateGenerator((new Date()), vz.options.plot.xaxis);
+			if ((jetzt - d) > (1000 * 60 * 60 * 24)) {
+                                vz.wui.legend.eq(i).text(series.title + ": " + $.plot.formatDate(d, '%d.%m.%y - %H:%M') + " - " + y.toFixed(1) + $
+                        } else {
+                                vz.wui.legend.eq(i).text(series.title + ": " + $.plot.formatDate(d, '%H:%M:%S') + " - " + y.toFixed(1) + " " + $
+                        }
 		}
 	}
 

--- a/htdocs/frontend/javascripts/wui.js
+++ b/htdocs/frontend/javascripts/wui.js
@@ -524,9 +524,9 @@ vz.wui.updateLegend = function() {
 			var d = $.plot.dateGenerator(pos.x, vz.options.plot.xaxis);
 			var jetzt = $.plot.dateGenerator((new Date()), vz.options.plot.xaxis);
 			if ((jetzt - d) > (1000 * 60 * 60 * 24)) {
-                                vz.wui.legend.eq(i).text(series.title + ": " + $.plot.formatDate(d, '%d.%m.%y - %H:%M') + " - " + y.toFixed(1) + $
-                        } else {
-                                vz.wui.legend.eq(i).text(series.title + ": " + $.plot.formatDate(d, '%H:%M:%S') + " - " + y.toFixed(1) + " " + $
+				vz.wui.legend.eq(i).text(series.title + ": " + $.plot.formatDate(d, '%d.%m.%y - %H:%M') + " - " + y.toFixed(1) + $
+			} else {
+                        	vz.wui.legend.eq(i).text(series.title + ": " + $.plot.formatDate(d, '%H:%M:%S') + " - " + y.toFixed(1) + " " + $
                         }
 		}
 	}

--- a/htdocs/frontend/javascripts/wui.js
+++ b/htdocs/frontend/javascripts/wui.js
@@ -522,12 +522,15 @@ vz.wui.updateLegend = function() {
 		} else {
 			// use plot wrapper instead of `new Date()` for timezone support
 			var d = $.plot.dateGenerator(pos.x, vz.options.plot.xaxis);
-			var jetzt = $.plot.dateGenerator((new Date()), vz.options.plot.xaxis);
-			if ((jetzt - d) > (1000 * 60 * 60 * 24)) {
-				vz.wui.legend.eq(i).text(series.title + ": " + $.plot.formatDate(d, '%d.%m.%y - %H:%M') + " - " + y.toFixed(1) + $
+			var delta = vz.options.plot.xaxis.max - vz.options.plot.xaxis.min;
+			var format;
+			// Interval more than 1 day ?
+			if(delta > 1*24*3600*1000) { 
+				format = '%d.%m.%y - %H:%M';
 			} else {
-				vz.wui.legend.eq(i).text(series.title + ": " + $.plot.formatDate(d, '%H:%M:%S') + " - " + y.toFixed(1) + " " + $
+				format = '%H:%M:%S';
 			}
+			vz.wui.legend.eq(i).text(series.title + ": " + $.plot.formatDate(d,format) + " - " + y.toFixed(0) + " " + series.unit);
 		}
 	}
 


### PR DESCRIPTION
Die Änderung bewirkt, dass die Legende das Datum mit anzeigt (Uhrzeit dann ohne sekunden) wenn das aktuelle Datum weiter als einen Tag vom Cursor entfernt ist. Bitte Zeile 525 kontrollieren, ob das mit dem Timezone-Support so funktioniert (aktuelles Datum).