### PR TITLE
Fix hour unit special case

### DIFF
--- a/htdocs/frontend/javascripts/wui.js
+++ b/htdocs/frontend/javascripts/wui.js
@@ -700,7 +700,7 @@ vz.wui.formatConsumptionUnit = function(unit) {
 	if (unit.indexOf(suffix, unit.length - suffix.length) !== -1) {
 		unit = unit.substring(0, unit.length - suffix.length);
 	}
-	else {
+	else if (unit !== 'h') {
 		unit += 'h';
 	}
 


### PR DESCRIPTION
Follow-on fix for https://github.com/volkszaehler/volkszaehler.org/issues/196 for Betriebsstundenzähler. It remains debatable how consumption for Betriebsstundenzähler should be handled at all.