### PR TITLE
Allow js-compatible timestamps for from/to in frontend

### DIFF
--- a/htdocs/frontend/javascripts/functions.js
+++ b/htdocs/frontend/javascripts/functions.js
@@ -186,16 +186,18 @@ vz.parseUrlParams = function() {
 					break;
 
 				case 'from':
-					vz.options.plot.xaxis.min = parseInt(vars[key]);
-					break;
-
 				case 'to':
-					vz.options.plot.xaxis.max = parseInt(vars[key]);
+					// ms or speaking timestamp
+					var ts = (/^-?[0-9]+$/.test(vars[key])) ? parseInt(vars[key]) : new Date(vars[key]).getTime();
+					if (key == 'from')
+						vz.options.plot.xaxis.min = ts;
+					else
+						vz.options.plot.xaxis.max = ts;
 					break;
 
-                                case 'options':
-                                        vz.options.options = vars[key];
-                                        break;
+				case 'options':
+					vz.options.options = vars[key];
+					break;
 			}
 		}
 	}


### PR DESCRIPTION
Follow-on to https://github.com/volkszaehler/volkszaehler.org/pull/197 for frontend instead of middleware, e.g. append `?from=2015-01-01T00:00` to the frontend url.