### PR TITLE
Performance: add chaching

### DIFF
--- a/etc/volkszaehler.conf.template.php
+++ b/etc/volkszaehler.conf.template.php
@@ -121,6 +121,7 @@ $config['colors'] = array('#83CAFF', '#7E0021', '#579D1C', '#FFD320', '#FF420E',
  * This disables all caching mechanisms and enabled debugging by default
  */
 $config['devmode']				= FALSE;
+$config['cache']['ttl']			= 3600;	// only used if devmode == FALSE
 
 /**
  * Debugging level

--- a/lib/Volkszaehler/Controller/Controller.php
+++ b/lib/Volkszaehler/Controller/Controller.php
@@ -41,7 +41,7 @@ abstract class Controller {
 	 * @param View $view
 	 * @param EntityManager $em
 	 */
-	public function __construct(/*View\View*/ $view, \Doctrine\ORM\EntityManager $em) {
+	public function __construct(View\View $view = null, \Doctrine\ORM\EntityManager $em) {
 		$this->view = $view;
 		$this->em = $em;
 	}

--- a/lib/Volkszaehler/Controller/DataController.php
+++ b/lib/Volkszaehler/Controller/DataController.php
@@ -62,7 +62,7 @@ class DataController extends Controller {
 
 			$interpreters = array();
 			foreach ($uuids as $uuid) {
-				$entity = $ec->get($uuid);
+				$entity = $ec->getSingleEntity($uuid, true); // from cache
 				$interpreters[] = $this->get($entity);
 			}
 
@@ -126,7 +126,7 @@ class DataController extends Controller {
 	public function run($operation, array $identifiers = array()) {
 		$ec = new EntityController($this->view, $this->em);
 
-		$entity = isset($identifiers[0]) ? $ec->get($identifiers[0]) : null;
+		$entity = isset($identifiers[0]) ? $ec->getSingleEntity($identifiers[0], true) : null; // from cache
 		return $this->{$operation}($entity);
 	}
 }

--- a/lib/Volkszaehler/Interpreter/AggregatorInterpreter.php
+++ b/lib/Volkszaehler/Interpreter/AggregatorInterpreter.php
@@ -67,17 +67,6 @@ class AggregatorInterpreter extends Interpreter {
 	}
 
 	/**
-	 * Just a passthrough to the channel interpreters
-	 *
-	 * @param string|integer $groupBy
-	 * @todo to be implemented
-	 * @return array of values
-	 */
-	public function processData($callback) {
-
-	}
-
-	/**
 	 * Get total consumption of all channels
 	 *
 	 * @todo to be implemented

--- a/lib/Volkszaehler/Router.php
+++ b/lib/Volkszaehler/Router.php
@@ -202,6 +202,10 @@ class Router {
 				$config->setQueryCacheImpl($cache);
 			}
 		}
+		else if (extension_loaded('apc')) {
+			// clear cache
+			apc_clear_cache('user');
+		}
 
 		$driverImpl = $config->newDefaultAnnotationDriver(VZ_DIR . '/lib/Volkszaehler/Model');
 		$config->setMetadataDriverImpl($driverImpl);

--- a/lib/Volkszaehler/View/JSON.php
+++ b/lib/Volkszaehler/View/JSON.php
@@ -224,15 +224,15 @@ class JSON extends View {
 	 * @param boolean $children
 	 */
 	protected function addData($interpreter, $children = false) {
-		$data = $interpreter->processData( // iterate through PDO resultset
-			function($tuple) {
-				return array(
-					$tuple[0],
-					View::formatNumber($tuple[1]),
-					$tuple[2]
-				);
-			}
-		);
+		$data = array();
+		// iterate through PDO resultset
+		foreach ($interpreter as $tuple) {
+			$data[] = array(
+				$tuple[0],
+				View::formatNumber($tuple[1]),
+				$tuple[2]
+			);
+		}
 
 		$from = 0 + $interpreter->getFrom();
 		$to = 0 + $interpreter->getTo();
@@ -252,8 +252,9 @@ class JSON extends View {
 
 		$wrapper['rows'] = $interpreter->getRowCount();
 
-		if (($interpreter->getTupleCount() > 0 || is_null($interpreter->getTupleCount())) && count($data) > 0)
+		if (($interpreter->getTupleCount() > 0 || is_null($interpreter->getTupleCount())) && count($data) > 0) {
 			$wrapper['tuples'] = $data;
+		}
 
 		if (!isset($this->json['data'])) {
 			// make sure json['data'] is initialized when child data is added

--- a/lib/Volkszaehler/View/JpGraph.php
+++ b/lib/Volkszaehler/View/JpGraph.php
@@ -150,10 +150,12 @@ class JpGraph extends View {
 			$interpreter->setTupleCount($this->width);
 		}
 
-		$data = $interpreter->processData(function($tuple) {
+		$data = array();
+		// iterate through PDO resultset
+		foreach ($interpreter as $tuple) {
 			$tuple[0] /= 1000;
-			return $tuple;
-		});
+			$data[] = $tuple;
+		}
 
 		if (count($data) > 0) {
 			$xData = $yData = array();

--- a/lib/Volkszaehler/View/XML.php
+++ b/lib/Volkszaehler/View/XML.php
@@ -282,17 +282,14 @@ class XML extends View {
 							   : $this->obtainElementById('data');
 		$xmlTuples = $this->xmlDoc->createElement('tuples');
 
-		$data = $interpreter->processData(
-			function($tuple) use ($xmlDoc, $xmlTuples) {
-				$xmlTuple = $xmlDoc->createElement('tuple');
-				$xmlTuple->setAttribute('timestamp', $tuple[0]);
-				$xmlTuple->setAttribute('value', View::formatNumber($tuple[1]));
-				$xmlTuple->setAttribute('count', $tuple[2]);
-				$xmlTuples->appendChild($xmlTuple);
-
-				return $tuple;
-			}
-		);
+		// iterate through PDO resultset
+		foreach ($interpreter as $tuple) {
+			$xmlTuple = $xmlDoc->createElement('tuple');
+			$xmlTuple->setAttribute('timestamp', $tuple[0]);
+			$xmlTuple->setAttribute('value', View::formatNumber($tuple[1]));
+			$xmlTuple->setAttribute('count', $tuple[2]);
+			$xmlTuples->appendChild($xmlTuple);
+		}
 
 		$from = $interpreter->getFrom();
 		$to = $interpreter->getTo();
@@ -330,8 +327,9 @@ class XML extends View {
 
 		$xmlData->appendChild($this->xmlDoc->createElement('rows', $interpreter->getRowCount()));
 
-		if (($interpreter->getTupleCount() > 0 || is_null($interpreter->getTupleCount())) && count($data) > 0)
+		if (($interpreter->getTupleCount() > 0 || is_null($interpreter->getTupleCount())) && count($xmlTuples) > 0) {
 			$xmlData->appendChild($xmlTuples);
+		}
 
 		if ($children) {
 			$xmlChildren = $this->obtainElementById('children');


### PR DESCRIPTION
Requires APCu installed (default on raspi):

  - cache entity query results from db (entities rarely change)
  - cache expensive reading and parsing of EntityDefinition.json and PropertyDefinition.json

On my windows test machine this PR takes ~20-30% off every call to `entity.json` and reduces the same amount of time from calls to `data.json`.

**NOTE**: this should be tested/ confirmed on RasPi, combined with creating and editing entities.