### PR TITLE
Add apc(u) to travis for testing caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,10 @@ before_script:
     - DATABASE=travis
     - USER=travis
     - PASSWORD=
-    - echo $USER
+
+    # add apc cache
+    - chmod +x ./test/bin/install-apcu.sh && ./test/bin/install-apcu.sh
+    - phpenv config-add ./test/bin/apc.ini
 
     # fix username before default rules apply
     - sh -c "if [ '$DB' = 'pgsql' ]; then sed -i 's/'\''vz'\''/'\''postgres'\''/' etc/volkszaehler.conf.php; fi;"

--- a/test/bin/apc.ini
+++ b/test/bin/apc.ini
@@ -1,0 +1,2 @@
+; your general apc settings go here
+apc.enable_cli=1

--- a/test/bin/install-apcu.sh
+++ b/test/bin/install-apcu.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ "$TRAVIS_PHP_VERSION" == "5.3" ] || [ "$TRAVIS_PHP_VERSION" == "5.4" ]
+then
+    exit 0
+fi
+
+echo "no" | pecl install apcu-beta


### PR DESCRIPTION
Update build infrastructure to prevent problems from https://github.com/volkszaehler/volkszaehler.org/pull/228 happening again. Caching was not tested in travis as apcu was not active for PHP cli. This is changed by this PR.