### PR TITLE
fix for issue #231

### DIFF
--- a/htdocs/frontend/javascripts/options.js
+++ b/htdocs/frontend/javascripts/options.js
@@ -36,7 +36,7 @@ vz.options = {
 	localMiddleware: '../middleware.php',
 	remoteMiddleware: [{
 		title: 'Volkszaehler Demo',
-		url: 'https://demo.volkszaehler.org/middleware.php'
+		url: '//demo.volkszaehler.org/middleware.php'
 	}],
 	monthNames: ['Jan', 'Feb', unescape('M%E4r'), 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez'],
 	dayNames: ['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa'],


### PR DESCRIPTION
according to http://en.wikipedia.org/wiki/Uniform_resource_locator#Protocol-relative_URLs a URL like this:
"//domain/path" is complete without protocol and ":"
This solves (both issues in) #231