### PR TITLE
Ensure data table has a default value generated on PostgreSQL

### DIFF
--- a/lib/Volkszaehler/Model/Data.php
+++ b/lib/Volkszaehler/Model/Data.php
@@ -44,7 +44,7 @@ class Data {
 	/**
 	 * @Id
 	 * @Column(type="integer", nullable=false)
-	 * @GeneratedValue(strategy="AUTO")
+	 * @GeneratedValue(strategy="IDENTITY")
 	 *
 	 * @todo wait until DDC-117 is fixed (PKs on FKs)
 	 */


### PR DESCRIPTION
The default `AUTO` strategy doesn't ensure a default value is generated. Breaks using SQL with PostgresSQL.