### PR TITLE
Don't fail frontend init if a deleted entity is stored in cookie

### DIFF
--- a/htdocs/frontend/javascripts/entities.js
+++ b/htdocs/frontend/javascripts/entities.js
@@ -91,14 +91,21 @@ vz.entities.loadMultipleDetails = function(entities) {
 		data: {
 			uuid: entities.map(function(entity) {
 				return entity.uuid;
-			})
+			}),
+			nostrict: 1, // don't fail if entity was removed
 		},
 		success: function(json) {
 			// @todo assuming unique UUIDs across middlewares
 			this.each(function(entity) {
 				json.entities.some(function(jsonEntity) {
 					if (jsonEntity.uuid == entity.uuid) { // entity matched
-						entity.parseJSON(jsonEntity);
+						if (jsonEntity.type == undefined) {
+							// entity does not exist at server- remove from list of entities
+							vz.entities.remove(entity)
+						}
+						else {
+							entity.parseJSON(jsonEntity);
+						}
 						return true;
 					}
 				});

--- a/lib/Volkszaehler/Controller/EntityController.php
+++ b/lib/Volkszaehler/Controller/EntityController.php
@@ -52,9 +52,23 @@ class EntityController extends Controller {
 		}
 		elseif (is_array($uuids = $this->view->request->getParameter('uuid'))) { // multiple entities
 			$entities = array();
+			$allowInvalidUuid = $this->view->request->getParameter('nostrict');
+
 			foreach ($uuids as $uuid) {
-				$entities[] = $this->getSingleEntity($uuid);
+				try {
+					$entities[] = $this->getSingleEntity($uuid);
+				}
+				catch (\Exception $e) {
+					if ($allowInvalidUuid) {
+						// return empty entity
+						$entities[] = array('uuid' => $uuid);
+					}
+					else {
+						throw $e;
+					}
+				}
 			}
+
 			return array('entities' => $entities);
 		}
 		else { // public entities


### PR DESCRIPTION
Add nostrict parameter to EntityController to allow graceful handling of deleted entities