### PR TITLE
Build infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,7 @@ notifications:
     mail: "volkszaehler-dev@lists.volkszaehler.org"
     irc: "chat.freenode.net#volkszaehler.org"
 
-before_install:
-    - if [ "$DEPENDENCIES" = true ]; then composer self-update; fi;
-
 install:
-    - cat composer.json
     - if [ "$DEPENDENCIES" = true ]; then composer install; fi;
     - if [ "$JSLINT" = true ]; then npm install; fi;
 
@@ -46,10 +42,8 @@ before_script:
     - cp etc/volkszaehler.conf.template.php etc/volkszaehler.conf.php
 
     - DATABASE=travis
-    - USER=travis
-    - if [ "$DB" = "pgsql" ]; then USER=postgres; fi;
+    - if [ ! "$DB" = "pgsql" ]; then USER=travis; else USER=postgres; fi;
     - PASSWORD=
-    - echo $USER
 
     # create config file
     - sed -i "s/'pdo_mysql'/'pdo_$DB'/" etc/volkszaehler.conf.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,69 +11,80 @@ services:
     - postgresql
 
 env:
+  # run composer by default
+  global:
+    - DEPENDENCIES=true
+  matrix:
     - DB=mysql
     - DB=pgsql
     - DB=sqlite
+
+matrix:
+  # add jslint-only job to the build matrix
+  include:
+    - php: 5.6
+      env: DB= DEPENDENCIES= JSLINT=true
+#  include:
+#    - php: 5.6
+#      env: DB=mysql TESTADAPTER=HTTPD
 
 notifications:
     mail: "volkszaehler-dev@lists.volkszaehler.org"
     irc: "chat.freenode.net#volkszaehler.org"
 
 before_install:
-    - composer self-update
+    - if [ "$DEPENDENCIES" = true ]; then composer self-update; fi;
 
 install:
-    - composer install
-    - npm install
+    - cat composer.json
+    - if [ "$DEPENDENCIES" = true ]; then composer install; fi;
+    - if [ "$JSLINT" = true ]; then npm install; fi;
 
 before_script:
+    # enable shell errors
+    - set -e
     - cp etc/volkszaehler.conf.template.php etc/volkszaehler.conf.php
 
     - DATABASE=travis
     - USER=travis
+    - if [ "$DB" = "pgsql" ]; then USER=postgres; fi;
     - PASSWORD=
+    - echo $USER
 
-    # add apc cache
-    - chmod +x ./test/bin/install-apcu.sh && ./test/bin/install-apcu.sh
-    - phpenv config-add ./test/bin/apc.ini
-
-    # fix username before default rules apply
-    - sh -c "if [ '$DB' = 'pgsql' ]; then sed -i 's/'\''vz'\''/'\''postgres'\''/' etc/volkszaehler.conf.php; fi;"
-
+    # create config file
     - sed -i "s/'pdo_mysql'/'pdo_$DB'/" etc/volkszaehler.conf.php
     - sed -i "s/'vz'/'$USER'/" etc/volkszaehler.conf.php
     - sed -i "s/'demo'/'$PASSWORD'/" etc/volkszaehler.conf.php
     - sed -i "s/'volkszaehler'/'$DATABASE'/" etc/volkszaehler.conf.php
-
+    - if [ "$DB" = "sqlite" ]; then sed -i "s/\?>/\$config['db']['path']\ =\ VZ_DIR.'\/sqlite.db3'\n?>/" etc/volkszaehler.conf.php; fi;
     - cat etc/volkszaehler.conf.php
 
-    - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'create database $DATABASE;' -u $USER; fi;"
-    - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'create database $DATABASE;' -U postgres; fi;"
-    - sh -c "if [ '$DB' = 'sqlite' ]; then sed -i 's/\?>/\$config['\''db'\'']['\''path'\'']\ =\ VZ_DIR.'\''\/sqlite.db3'\''\n?>/' etc/volkszaehler.conf.php; fi;"
+    # create database
+    - if [ "$DB" = "mysql" ]; then mysql -e "create database $DATABASE;" -u $USER; fi;
+    - if [ "$DB" = "pgsql" ]; then psql -c "create database $DATABASE;" -U postgres; fi;
 
-    - cat etc/volkszaehler.conf.php
+    # create schema
+    - if [ -n "$DB" ]; then php misc/tools/doctrine orm:schema-tool:create --dump-sql > misc/sql/schema.sql; fi;
+    - if [ -n "$DB" ]; then sed -i 's/ATTENTION/-- /' misc/sql/schema.sql; fi;
+    - if [ -n "$DB" ]; then echo ';' >> misc/sql/schema.sql; fi;
+    - if [ -n "$DB" ]; then cat misc/sql/schema.sql; fi;
 
-    - php misc/tools/doctrine orm:schema-tool:create --dump-sql > misc/sql/schema.sql
-    - sed -i 's/ATTENTION/-- /' misc/sql/schema.sql
-    - echo ';' >> misc/sql/schema.sql
-
-    - cat misc/sql/schema.sql
-
-    - sh -c "if [ '$DB' = 'mysql' ]; then cat misc/sql/schema.sql | mysql -u $USER $DATABASE; fi;"
-    - sh -c "if [ '$DB' = 'pgsql' ]; then cat misc/sql/schema.sql | psql -U postgres $DATABASE; fi;"
-    - sh -c "if [ '$DB' = 'sqlite' ]; then cat misc/sql/schema.sql | sqlite3 sqlite.db3; sqlite3 sqlite.db3 .dump; fi;"
+    - if [ "$DB" = "mysql" ]; then cat misc/sql/schema.sql | mysql -u $USER $DATABASE; fi;
+    - if [ "$DB" = "pgsql" ]; then cat misc/sql/schema.sql | psql -U postgres $DATABASE; fi;
+    - if [ "$DB" = "sqlite" ]; then cat misc/sql/schema.sql | sqlite3 sqlite.db3; sqlite3 sqlite.db3 .dump; fi;
 
 script:
     - cd test
-    - phpunit --exclude-group aggregation --coverage-text
+    # run core tests
+    - if [ -n "$DB" ]; then phpunit --exclude-group aggregation --coverage-text; fi;
 
     # re-run with aggregation enabled
-    - sed -i "s/\?>/\$config['aggregation']\ =\ true;\n?>/" ../etc/volkszaehler.conf.php
-    - sh -c "if [ '$DB' = 'mysql' ]; then phpunit --coverage-text; fi;"
+    - if [ "$DB" = "mysql" ]; then sed -i "s/\?>/\$config['aggregation']\ =\ true;\n?>/" ../etc/volkszaehler.conf.php; fi;
+    - if [ "$DB" = "mysql" ]; then phpunit --coverage-text; fi;
+    - cd ..
 
     # test running aggregation tool
-    - cd ..
-    - sh -c "if [ '$DB' = 'mysql' ]; then php misc/tools/aggregate.php run -m delta -l hour; fi;"
+    - if [ "$DB" = "mysql" ]; then php misc/tools/aggregate.php run -m delta -l hour; fi;
 
     # jslint javascript sources
-    - gulp jshint
+    - if [ "$JSLINT" = true ]; then gulp jshint; fi;

--- a/lib/Volkszaehler/Model/Aggregate.php
+++ b/lib/Volkszaehler/Model/Aggregate.php
@@ -35,7 +35,6 @@ use Volkszaehler\Model;
  * @Entity
  * @Table(
  * 	name="aggregate",
- *	indexes={@index(name="search_idx", columns={"channel_id", "type", "timestamp"})},
  *	uniqueConstraints={@UniqueConstraint(name="aggregate_unique", columns={"channel_id", "type", "timestamp"})}
  * )
  */

--- a/lib/Volkszaehler/Model/Data.php
+++ b/lib/Volkszaehler/Model/Data.php
@@ -31,12 +31,10 @@ use Volkszaehler\Model;
  *
  * @author Steffen Vogel <info@steffenvogel.de>
  * @package default
- * @todo rename? Bsp: DataSample, Sample, Reading
  *
  * @Entity
  * @Table(
  * 	name="data",
- *	indexes={@index(name="search_idx", columns={"channel_id", "timestamp"})},
  *	uniqueConstraints={@UniqueConstraint(name="data_unique", columns={"channel_id", "timestamp"})}
  * )
  */


### PR DESCRIPTION
This PR provides a cleanup of the travis build process:

  - build script cleaned
  - speedup of build by removing redundant dependencies
  - added missing error handling

After cleanup I've realized that build actually (and silently) failed when running on sqlite due to a duplicate index name. The duplicate indexes were removed as they're not even required due to unique constraints being in place. This might result in slightly improved DB performance especially when writing.

To apply the DB changes perform a backup and run:

	php misc\tools\doctrine orm:schema-tool:update --force