### PR TITLE
Abbruch bei Installation von jpgraph verhindern

### DIFF
--- a/misc/tools/install.sh
+++ b/misc/tools/install.sh
@@ -184,7 +184,7 @@ pushd "$vz_dir"
 echo
 ask "install server-side graph generation (jpgraph, not required for frontend)?" n
 if [ "$REPLY" == "y" ]; then
-	"$COMPOSER" require jpgraph/jpgraph:dev-master
+	"$COMPOSER" require --update-no-dev jpgraph/jpgraph:dev-master
 fi
 popd
 


### PR DESCRIPTION
Dieser Fehler kam:

install server-side graph generation (jpgraph, not required for frontend)? [n] y
./composer.json has been updated


                                                                                                                                         
  [RuntimeException]                                                                                                                     
  The lock file does not contain require-dev information, run install with the --no-dev option or run update to install those packages.