### PR TITLE
Reduce data to json memory usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "andig/dbcopy": "dev-master",
         "symfony/console": "2.6.*",
         "symfony/http-kernel": "2.6.*",
-        "symfony/http-foundation": "2.6.*"
+        "symfony/http-foundation": "2.6.*",
+        "zendframework/zend-json": "2.4.*"
     },
     "require-dev": {
         "phpunit/phpunit": "4.4.*"

--- a/lib/Volkszaehler/Controller/DataController.php
+++ b/lib/Volkszaehler/Controller/DataController.php
@@ -96,11 +96,11 @@ class DataController extends Controller {
 			}
 
 			// convert nested ArrayObject to plain array with flattened tuples
-			$data = array_reduce($json->getArrayCopy(), function($carry, $tuple) {
+			$data = array_reduce($json, function($carry, $tuple) {
 				return array_merge($carry, $tuple);
 			}, array());
 		}
-		catch (Util\JSONException $e) { /* fallback to old method */
+		catch (\RuntimeException $e) { /* fallback to old method */
 			$timestamp = $this->request->parameters->get('ts');
 			$value = $this->request->parameters->get('value');
 

--- a/lib/Volkszaehler/View/XML.php
+++ b/lib/Volkszaehler/View/XML.php
@@ -329,7 +329,7 @@ class XML extends View {
 
 		$xmlData->appendChild($this->xmlDoc->createElement('rows', $interpreter->getRowCount()));
 
-		if (($interpreter->getTupleCount() > 0 || is_null($interpreter->getTupleCount())) && count($xmlTuples) > 0) {
+		if (count($xmlTuples) > 0) {
 			$xmlData->appendChild($xmlTuples);
 		}
 

--- a/test/Tests/CapabilitiesTest.php
+++ b/test/Tests/CapabilitiesTest.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Capability tests
+ *
+ * @package Test
+ * @author Andreas Götz <cpuidle@gmx.de>
+ */
+
+namespace Tests;
+
+class CapabilitiesTest extends Middleware
+{
+	function testExistence() {
+		$this->assertNotNull($this->getJson('/capabilities.json')->capabilities);
+		$this->assertInternalType('object', $this->getJson('/capabilities.json')->capabilities);
+	}
+}
+
+?>

--- a/test/Tests/ChannelTest.php
+++ b/test/Tests/ChannelTest.php
@@ -35,9 +35,9 @@ class ChannelTest extends Middleware
 		);
 	}
 
-	function testListChannels() {
-		$url = '/channel.json';
-		$this->getJson($url);
+	function testExistence() {
+		$this->assertNotNull($this->getJson('/channel.json')->channels);
+		$this->assertInternalType('array', $this->getJson('/channel.json')->channels);
 	}
 
 	/**

--- a/test/Tests/Data.php
+++ b/test/Tests/Data.php
@@ -103,8 +103,8 @@ abstract class Data extends Middleware
 	 * Helper assertion to validate correct UUID
 	 */
 	protected function assertUUID() {
-		$this->assertEquals(static::$uuid, (isset($this->json->data->uuid) ? $this->json->data->uuid : null),
-			"Wrong UUID. Expected " . static::$uuid . ", got " . $this->json->data->uuid);
+		$uuid = isset($this->json->data->uuid) ? $this->json->data->uuid : null;
+		$this->assertEquals(static::$uuid, $uuid, "Wrong UUID. Expected " . static::$uuid . ", got " . ($uuid ?: '<null>'));
 	}
 
 	/**

--- a/test/Tests/EntityTest.php
+++ b/test/Tests/EntityTest.php
@@ -12,6 +12,11 @@ class EntityTest extends Middleware
 {
 	static $uuid;
 
+	function testExistence() {
+		$this->assertNotNull($this->getJson('/entity.json')->entities);
+		$this->assertInternalType('array', $this->getJson('/entity.json')->entities);
+	}
+
 	function testCreateEntity() {
 		// entities cannot be created - expect json exception
 		$this->getJson('/entity.json', array(

--- a/test/Tests/GroupTest.php
+++ b/test/Tests/GroupTest.php
@@ -12,6 +12,12 @@ class GroupTest extends Middleware
 {
 	static $uuid;
 
+	function testExistence() {
+		// create group
+		$this->assertNotNull($this->getJson('/group.json')->channels);
+		$this->assertInternalType('array', $this->getJson('/group.json')->channels);
+	}
+
 	function testCreateGroup() {
 		// create group
 		self::$uuid = $this->getJson('/group.json', array(


### PR DESCRIPTION
Fix #303 

Reduces memory usage by printing large number of tuples directly to output using `Symfony\StreamedResponse` instead of storing as php arrays before being encoded to json.

Requires php 5.4.0 as `StreamedResponse->setCallback()` takes a closure with access to `$this`.