### PR TITLE
Require recent doctrine/dbal version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "prefer-stable": true,
     "require": {
         "doctrine/orm": "2.4.*",
+        "doctrine/dbal": "2.5.*",
         "andig/dbcopy": "dev-master",
         "symfony/console": "2.6.*",
         "symfony/http-kernel": "2.6.*"


### PR DESCRIPTION
Fix https://github.com/volkszaehler/volkszaehler.org/issues/300 by ensuring `doctrine\dbal` is a recent version. 