### PR TITLE
Fix auto refresh gui inconsistency

### DIFF
--- a/htdocs/frontend/javascripts/functions.js
+++ b/htdocs/frontend/javascripts/functions.js
@@ -187,7 +187,7 @@ vz.parseUrlParams = function() {
 
 				case 'from':
 				case 'to':
-					// disabled automatic refresh
+					// disable automatic refresh
 					vz.options.refresh = false;
 					// ms or speaking timestamp
 					var ts = (/^-?[0-9]+$/.test(vars[key])) ? parseInt(vars[key]) : new Date(vars[key]).getTime();
@@ -201,7 +201,7 @@ vz.parseUrlParams = function() {
 					vz.options[key] = vars[key];
 					break;
 
-				case 'options':
+				case 'options': // data load options
 					vz.options.options = vars[key];
 					break;
 			}

--- a/htdocs/frontend/javascripts/options.js
+++ b/htdocs/frontend/javascripts/options.js
@@ -28,7 +28,7 @@ vz.options = {
 	language: 'de',
 	precision: 2,		// TODO update from middleware capabilities?
 	tuples: null,		// automatically determined by plot size
-	refresh: false,
+	refresh: true,	// update chart if zoomed to current timestamp
 	totalsInterval: 300,	// update interval for consumption is retrieved for each channel where initialconsumption > 0
 	shortenLongTypes: false, // show shorter type names in table
 	minTimeout: 2000,	// minimum refresh time in ms

--- a/htdocs/frontend/javascripts/wui.js
+++ b/htdocs/frontend/javascripts/wui.js
@@ -96,8 +96,8 @@ vz.wui.init = function() {
 	$('#controls').buttonset();
 
 	// auto refresh
+	$('#refresh').prop('checked', vz.options.refresh);
 	if (vz.options.refresh) {
-		$('#refresh').prop('checked', true);
 		vz.wui.tmaxnow = true;
 		vz.wui.setTimeout();
 	}


### PR DESCRIPTION
Without this fix, the `refresh` checkbox will be checked although `options.refresh = false`. Also enables refresh by default.