### PR TITLE
Remove outer margin

### DIFF
--- a/htdocs/frontend/stylesheets/style.css
+++ b/htdocs/frontend/stylesheets/style.css
@@ -27,13 +27,8 @@ tr.property td, tr.entity td {
 }
 
 #content {
-	margin: 10px 10px 10px;
 	padding: 10px;
 	background-color: white;
-	border: 1px solid black;
-	-moz-border-radius: 10px;
-	-webkit-border-radius: 10px;
-	border-radius: 10px;
 }
 
 #content div {


### PR DESCRIPTION
Make better use of screen estate. Removes outer margin, border and rounded corners.

**vorher**:
![vorher](https://cloud.githubusercontent.com/assets/184815/8179659/5dbefd64-1418-11e5-8461-5782c7f051f1.png)

**nachher**:
![nachher](https://cloud.githubusercontent.com/assets/184815/8179666/6a9112ca-1418-11e5-8f06-ab16ac37e46c.png)
