### PR TITLE
Reduce data to json memory usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-    - 5.3
     - 5.4
     - 5.5
     - 5.6

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
+        "php": ">=5.4.0",
         "doctrine/orm": "2.4.*",
         "doctrine/dbal": "2.5.*",
         "andig/dbcopy": "dev-master",

--- a/lib/Volkszaehler/Controller/DataController.php
+++ b/lib/Volkszaehler/Controller/DataController.php
@@ -96,11 +96,11 @@ class DataController extends Controller {
 			}
 
 			// convert nested ArrayObject to plain array with flattened tuples
-			$data = array_reduce($json->getArrayCopy(), function($carry, $tuple) {
+			$data = array_reduce($json, function($carry, $tuple) {
 				return array_merge($carry, $tuple);
 			}, array());
 		}
-		catch (Util\JSONException $e) { /* fallback to old method */
+		catch (\RuntimeException $e) { /* fallback to old method */
 			$timestamp = $this->request->parameters->get('ts');
 			$value = $this->request->parameters->get('value');
 

--- a/lib/Volkszaehler/View/JSON.php
+++ b/lib/Volkszaehler/View/JSON.php
@@ -24,6 +24,7 @@
 namespace Volkszaehler\View;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 use Volkszaehler\Interpreter;
 use Volkszaehler\Util;
@@ -34,6 +35,7 @@ use Volkszaehler\Model;
  *
  * @package default
  * @author Steffen Vogel <info@steffenvogel.de>
+ * @author Andreas Goetz <cpuidle@gmx.de>
  */
 class JSON extends View {
 	/**
@@ -44,7 +46,7 @@ class JSON extends View {
 	/**
 	 * @var string padding function name or NULL if disabled
 	 */
-	protected $padding = FALSE;
+	protected $padding = false;
 
 	/**
 	 * Constructor
@@ -52,11 +54,27 @@ class JSON extends View {
 	public function __construct(Request $request) {
 		parent::__construct($request);
 
-		$this->json = new Util\JSON();
+		$this->json = array();
 		$this->json['version'] = VZ_VERSION;
 
-		// JSONP
-		if ($this->padding = $request->parameters->get('padding')) {
+		$this->padding = $request->parameters->get('padding');
+	}
+
+	/**
+	 * Render response and send it to the client
+	 */
+	public function send() {
+		// use StreamedResponse unless pretty-printing is required
+		if (Util\Debug::isActivated()) {
+			$this->add(Util\Debug::getInstance());
+		}
+		else {
+			$this->response = new StreamedResponse();
+		}
+
+		// set json headers
+		if ($this->padding) {
+			// JSONP
 			$this->response->headers->set('Content-Type', 'application/javascript');
 		}
 		else {
@@ -64,6 +82,28 @@ class JSON extends View {
 			// enable CORS if not JSONP
 			$this->response->headers->set('Access-Control-Allow-Origin', '*');
 		}
+
+		if ($this->response instanceof StreamedResponse) {
+			$this->response->setCallback(function() {
+				$this->renderDeferred();
+				flush();
+			});
+		}
+		else {
+			ob_start();
+			$this->renderDeferred();
+			$json = ob_get_contents();
+			ob_end_clean();
+
+			// padded response is js, not json
+			if (!$this->padding) {
+				$json = Util\Json::format($json);
+			}
+
+			$this->response->setContent($json);
+		}
+
+		return $this->response;
 	}
 
 	/**
@@ -78,6 +118,84 @@ class JSON extends View {
 		return $this->send();
 	}
 
+	protected function render() {
+		throw new \LogicException('Cannot call render when using StreamedResponse');
+	}
+
+	/**
+	 * Process, encode and print output to stdout
+	 */
+	protected function renderDeferred() {
+		if ($this->padding) echo($this->padding . '(');
+		echo('{');
+
+		$contentStarted = false;
+
+		foreach ($this->json as $key => $data) {
+			if ($contentStarted) {
+				echo(",");
+			}
+			$contentStarted = true;
+
+			echo('"' . $key . '":');
+
+			if ($data instanceof Interpreter\Interpreter) {
+				// single interpreter
+				$this->renderInterpreter($data);
+			}
+			elseif (is_array($data) && isset($data[0]) && $data[0] instanceof Interpreter\Interpreter) {
+				// array of interpreters
+				echo('[');
+				foreach ($data as $key => $interpreter) {
+					if ($key) echo(',');
+					$this->renderInterpreter($interpreter);
+				}
+				echo(']');
+			}
+			elseif ($data instanceof Util\Debug) {
+				echo(json_encode($this->convertDebug($data)));
+			}
+			else {
+				echo(json_encode($data));
+			}
+		}
+
+		echo('}');
+		if ($this->padding) echo(');');
+	}
+
+	/**
+	 * Render Interpreter output
+	 */
+	protected function renderInterpreter(Interpreter\Interpreter $interpreter) {
+		echo('{"tuples":[');
+
+		// start with iterating through PDO result set to populate interpreter header data
+		foreach ($interpreter as $key => $tuple) {
+			if ($key) echo(',');
+			echo('[' . $tuple[0] . ',' . View::formatNumber($tuple[1]) . ',' . $tuple[2] . ']');
+		}
+
+		$from = 0 + $interpreter->getFrom();
+		$to = 0 + $interpreter->getTo();
+		$min = $interpreter->getMin();
+		$max = $interpreter->getMax();
+		$average = $interpreter->getAverage();
+		$consumption = $interpreter->getConsumption();
+
+		$header = array();
+		$header['uuid'] = $interpreter->getEntity()->getUuid();
+		if (isset($from)) $header['from'] = $from;
+		if (isset($to)) $header['to'] = $to;
+		if (isset($min)) $header['min'] = $min;
+		if (isset($max)) $header['max'] = $max;
+		if (isset($average)) $header['average'] = View::formatNumber($average);
+		if (isset($consumption)) $header['consumption'] = View::formatNumber($consumption);
+		$header['rows'] = $interpreter->getRowCount();
+
+		echo('],' . substr(json_encode($header), 1, -1) . '}');
+	}
+
 	/**
 	 * Add object to output
 	 *
@@ -85,39 +203,23 @@ class JSON extends View {
 	 */
 	public function add($data) {
 		if ($data instanceof Interpreter\Interpreter) {
-			$this->addData($data);
-		}
-		elseif (is_array($data) && isset($data[0]) && $data[0] instanceof Interpreter\Interpreter) {
-			$this->addMultipleData($data);
+			$this->json['data'] = $data;
 		}
 		elseif ($data instanceof Model\Entity) {
 			$this->json['entity'] = self::convertEntity($data);
 		}
+		elseif ($data instanceof Util\Debug) {
+			$this->json['debug'] = $data;
+		}
 		elseif ($data instanceof \Exception) {
 			$this->addException($data);
 		}
-		elseif ($data instanceof Util\Debug) {
-			$this->addDebug($data);
-		}
-		elseif ($data instanceof Util\JSON || is_array($data)) {
+		elseif (is_array($data)) {
 			$this->addArray($data, $this->json);
 		}
 		elseif (isset($data)) { // ignores NULL data
 			throw new \Exception('Can\'t show: \'' . get_class($data) . '\'');
 		}
-	}
-
-	/**
-	 * Process, encode and print output to stdout
-	 */
-	protected function render() {
-		$json = $this->json->encode((Util\Debug::isActivated()) ? JSON_PRETTY : 0);
-
-		if ($this->padding) {
-			$json = $this->padding . '(' . $json . ');';
-		}
-
-		return $json;
 	}
 
 	/**
@@ -152,7 +254,7 @@ class JSON extends View {
 	 *
 	 * @param Util\Debug $debug
 	 */
-	protected function addDebug(Util\Debug $debug) {
+	protected function convertDebug(Util\Debug $debug) {
 		$jsonDebug['level'] = $debug->getLevel();
 		if ($dbDriver = Util\Configuration::read('db.driver')) $jsonDebug['database'] = $dbDriver;
 		$jsonDebug['time'] = $debug->getExecutionTime();
@@ -165,14 +267,47 @@ class JSON extends View {
 		$jsonDebug['messages'] = $debug->getMessages();
 
 		// SQL statements
-		$this->getSQLTimes($debug->getQueries());
-		$jsonDebug['sql'] = array(
-			'totalTime' => $this->sqlTotalTime,
-			'worstTime' => $this->sqlWorstTime,
-			'queries' => array_values($debug->getQueries())
-		);
+		if (count($statements = $debug->getQueries())) {
+			$this->getSQLTimes($statements);
+			$jsonDebug['sql'] = array(
+				'totalTime' => $this->sqlTotalTime,
+				'worstTime' => $this->sqlWorstTime,
+				'queries' => array_values($debug->getQueries())
+			);
+		}
 
-		$this->json['debug'] = $jsonDebug;
+		return $jsonDebug;
+	}
+
+	/**
+	 * Add an array of objects to the output
+	 */
+	protected function addArray($data, &$refNode) {
+		if (is_null($refNode)) {
+			$refNode = array();
+		}
+
+		foreach ($data as $index => $value) {
+			if (is_array($value)) {
+				$this->addArray($value, $refNode[$index]);
+			}
+			elseif ($value instanceof Model\Entity) {
+				$refNode[$index] = self::convertEntity($value);
+			}
+			elseif ($value instanceof Interpreter\Interpreter) {
+				// special case: interpreters are always added to the root node
+				if (!isset($this->json['data'])) {
+					$this->json['data'] = array();
+				}
+				$this->json['data'][] = $value;
+			}
+			elseif (is_numeric($value)) {
+				$refNode[$index] = View::formatNumber($value);
+			}
+			else {
+				$refNode[$index] = $value;
+			}
+		}
 	}
 
 	/**
@@ -200,92 +335,6 @@ class JSON extends View {
 		}
 		else {
 			$this->json['exception'] = $exceptionInfo;
-		}
-	}
-
-	/**
-	 * Add multiple data objects to output queue
-	 *
-	 * @param $interpreter
-	 */
-	protected function addMultipleData($data) {
-		foreach ($data as $interpreter) {
-			$this->addData($interpreter, true);
-		}
-		// correct structure
-		$this->json['data'] = $this->json['data']['children'];
-	}
-
-	/**
-	 * Add data to output queue
-	 *
-	 * @param $interpreter
-	 * @param boolean $children
-	 */
-	protected function addData($interpreter, $children = false) {
-		$data = array();
-		// iterate through PDO resultset
-		foreach ($interpreter as $tuple) {
-			$data[] = array(
-				$tuple[0],
-				View::formatNumber($tuple[1]),
-				$tuple[2]
-			);
-		}
-
-		$from = 0 + $interpreter->getFrom();
-		$to = 0 + $interpreter->getTo();
-		$min = $interpreter->getMin();
-		$max = $interpreter->getMax();
-		$average = $interpreter->getAverage();
-		$consumption = $interpreter->getConsumption();
-
-		$wrapper = array();
-		$wrapper['uuid'] = $interpreter->getEntity()->getUuid();
-		if (isset($from)) $wrapper['from'] = $from;
-		if (isset($to)) $wrapper['to'] = $to;
-		if (isset($min)) $wrapper['min'] = $min;
-		if (isset($max)) $wrapper['max'] = $max;
-		if (isset($average)) $wrapper['average'] = View::formatNumber($average);
-		if (isset($consumption)) $wrapper['consumption'] = View::formatNumber($consumption);
-
-		$wrapper['rows'] = $interpreter->getRowCount();
-
-		if (($interpreter->getTupleCount() > 0 || is_null($interpreter->getTupleCount())) && count($data) > 0) {
-			$wrapper['tuples'] = $data;
-		}
-
-		if (!isset($this->json['data'])) {
-			// make sure json['data'] is initialized when child data is added
-			$this->json['data'] = array();
-		}
-		if ($children == false) {
-			// preserve child data if existing
-			$this->json['data'] = array_merge($wrapper, $this->json['data']);
-		}
-		else {
-			$this->json['data']['children'][] = $wrapper;
-		}
-	}
-
-	protected function addArray($data, &$refNode) {
-		if (is_null($refNode)) {
-			$refNode = array();
-		}
-
-		foreach ($data as $index => $value) {
-			if ($value instanceof Util\JSON || is_array($value)) {
-				$this->addArray($value, $refNode[$index]);
-			}
-			elseif ($value instanceof Model\Entity) {
-				$refNode[$index] = self::convertEntity($value);
-			}
-			elseif (is_numeric($value)) {
-				$refNode[$index] = View::formatNumber($value);
-			}
-			else {
-				$refNode[$index] = $value;
-			}
 		}
 	}
 }

--- a/lib/Volkszaehler/View/XML.php
+++ b/lib/Volkszaehler/View/XML.php
@@ -329,7 +329,7 @@ class XML extends View {
 
 		$xmlData->appendChild($this->xmlDoc->createElement('rows', $interpreter->getRowCount()));
 
-		if (($interpreter->getTupleCount() > 0 || is_null($interpreter->getTupleCount())) && count($xmlTuples) > 0) {
+		if (count($xmlTuples) > 0) {
 			$xmlData->appendChild($xmlTuples);
 		}
 

--- a/test/Tests/CapabilitiesTest.php
+++ b/test/Tests/CapabilitiesTest.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Capability tests
+ *
+ * @package Test
+ * @author Andreas Götz <cpuidle@gmx.de>
+ */
+
+namespace Tests;
+
+class CapabilitiesTest extends Middleware
+{
+	function testExistence() {
+		$this->assertNotNull($this->getJson('/capabilities.json')->capabilities);
+		$this->assertInternalType('object', $this->getJson('/capabilities.json')->capabilities);
+	}
+}
+
+?>

--- a/test/Tests/ChannelTest.php
+++ b/test/Tests/ChannelTest.php
@@ -35,9 +35,9 @@ class ChannelTest extends Middleware
 		);
 	}
 
-	function testListChannels() {
-		$url = '/channel.json';
-		$this->getJson($url);
+	function testExistence() {
+		$this->assertNotNull($this->getJson('/channel.json')->channels);
+		$this->assertInternalType('array', $this->getJson('/channel.json')->channels);
 	}
 
 	/**

--- a/test/Tests/CounterTest.php
+++ b/test/Tests/CounterTest.php
@@ -68,8 +68,8 @@ class CounterTest extends Data
 		$this->assertFromTo($this->ts1, $this->ts1);
 		$this->assertHeader(0, 0, 1);
 
-		// tuples
-		$this->assertFalse(isset($this->json->data->tuples));
+		// tuples not set or empty array
+		$this->assertFalse(isset($this->json->data->tuples) && count($this->json->data->tuples));
 	}
 
 	/**
@@ -144,8 +144,8 @@ class CounterTest extends Data
 		$this->assertFromTo(0, 0);
 		$this->assertHeader(0, 0, 0);
 
-		// tuples
-		$this->assertFalse(isset($this->json->data->tuples));
+		// tuples not set or empty array
+		$this->assertFalse(isset($this->json->data->tuples) && count($this->json->data->tuples));
 	}
 
 	/**

--- a/test/Tests/Data.php
+++ b/test/Tests/Data.php
@@ -40,8 +40,7 @@ abstract class Data extends Middleware
 	static function createChannel($title, $type, $resolution = null) {
 		$url = '/channel.json?operation=add&title=' . urlencode($title) . '&type=' . urlencode($type);
 		if ($resolution) $url .= '&resolution=' . $resolution;
-		$json = self::executeRequest(Request::create($url));
-
+		$json = self::executeJsonRequest(Request::create($url));
 		return (isset($json->entity->uuid)) ? $json->entity->uuid : null;
 	}
 
@@ -50,7 +49,7 @@ abstract class Data extends Middleware
 	 */
 	static function deleteChannel($uuid) {
 		$url = '/channel/' . $uuid . '.json?operation=delete';
-		return self::executeRequest(Request::create($url));
+		return self::executeJsonRequest(Request::create($url));
 	}
 
 	/*
@@ -103,8 +102,8 @@ abstract class Data extends Middleware
 	 * Helper assertion to validate correct UUID
 	 */
 	protected function assertUUID() {
-		$this->assertEquals(static::$uuid, (isset($this->json->data->uuid) ? $this->json->data->uuid : null),
-			"Wrong UUID. Expected " . static::$uuid . ", got " . $this->json->data->uuid);
+		$uuid = isset($this->json->data->uuid) ? $this->json->data->uuid : null;
+		$this->assertEquals(static::$uuid, $uuid, "Wrong UUID. Expected " . static::$uuid . ", got " . ($uuid ?: '<null>'));
 	}
 
 	/**

--- a/test/Tests/EntityTest.php
+++ b/test/Tests/EntityTest.php
@@ -12,6 +12,11 @@ class EntityTest extends Middleware
 {
 	static $uuid;
 
+	function testExistence() {
+		$this->assertNotNull($this->getJson('/entity.json')->entities);
+		$this->assertInternalType('array', $this->getJson('/entity.json')->entities);
+	}
+
 	function testCreateEntity() {
 		// entities cannot be created - expect json exception
 		$this->getJson('/entity.json', array(

--- a/test/Tests/FormatTest.php
+++ b/test/Tests/FormatTest.php
@@ -21,7 +21,7 @@ class FormatTest extends Data
 		self::$uuid = self::createChannel('Meter', 'power', 1);
 
 		// add data
-		self::executeRequest(Request::create('/data/' . self::$uuid . '.json', 'POST',
+		self::executeJsonRequest(Request::create('/data/' . self::$uuid . '.json', 'POST',
 			array(), array(), array(), array(),
 			json_encode(array(
 				array(1000000, 1000),
@@ -35,7 +35,7 @@ class FormatTest extends Data
 	 * @group jpgraph
 	 */
 	function testImage() {
-		$response = $this->executeRequest(Request::create('/data/' . static::$uuid . '.png', 'GET',
+		$response = $this->getResponse(Request::create('/data/' . static::$uuid . '.png', 'GET',
 			array('from' => 0, 'to' => 'now')
 		));
 
@@ -49,7 +49,7 @@ class FormatTest extends Data
 	 * NOTE: this cannot be tested due to JpGraph design issues
 	 */
 	// function testImageInvalidUuidException() {
-	// 	$response = $this->executeRequest(Request::create('/data/' . self::INVALID_UUID . '.png', 'GET',
+	// 	$response = $this->getResponse(Request::create('/data/' . self::INVALID_UUID . '.png', 'GET',
 	// 		array('from' => 0, 'to' => 'now')
 	// 	));
 
@@ -58,7 +58,7 @@ class FormatTest extends Data
 	// }
 
 	function testCSV() {
-		$response = $this->executeRequest(Request::create('/data/' . static::$uuid . '.csv', 'GET',
+		$response = $this->getResponse(Request::create('/data/' . static::$uuid . '.csv', 'GET',
 			array('from' => 0, 'to' => 'now')
 		));
 
@@ -68,7 +68,7 @@ class FormatTest extends Data
 	}
 
 	function testCSVInvalidUuidException() {
-		$response = $this->executeRequest(Request::create('/data/' . self::INVALID_UUID . '.csv', 'GET',
+		$response = $this->getResponse(Request::create('/data/' . self::INVALID_UUID . '.csv', 'GET',
 			array('from' => 0, 'to' => 'now')
 		));
 
@@ -76,7 +76,7 @@ class FormatTest extends Data
 	}
 
 	function testXML() {
-		$response = $this->executeRequest(Request::create('/data/' . static::$uuid . '.xml', 'GET',
+		$response = $this->getResponse(Request::create('/data/' . static::$uuid . '.xml', 'GET',
 			array('from' => 0, 'to' => 'now')
 		));
 
@@ -86,7 +86,7 @@ class FormatTest extends Data
 	}
 
 	function testXMLInvalidUuidException() {
-		$response = $this->executeRequest(Request::create('/data/' . self::INVALID_UUID . '.xml', 'GET',
+		$response = $this->getResponse(Request::create('/data/' . self::INVALID_UUID . '.xml', 'GET',
 			array('from' => 0, 'to' => 'now')
 		));
 

--- a/test/Tests/GroupTest.php
+++ b/test/Tests/GroupTest.php
@@ -12,6 +12,12 @@ class GroupTest extends Middleware
 {
 	static $uuid;
 
+	function testExistence() {
+		// create group
+		$this->assertNotNull($this->getJson('/group.json')->channels);
+		$this->assertInternalType('array', $this->getJson('/group.json')->channels);
+	}
+
 	function testCreateGroup() {
 		// create group
 		self::$uuid = $this->getJson('/group.json', array(

--- a/test/Tests/MeterTest.php
+++ b/test/Tests/MeterTest.php
@@ -68,8 +68,8 @@ class MeterTest extends Data
 		$this->assertFromTo($this->ts1, $this->ts1);
 		$this->assertHeader(0, 0, 1);
 
-		// tuples
-		$this->assertFalse(isset($this->json->data->tuples));
+		// tuples not set or empty array
+		$this->assertFalse(isset($this->json->data->tuples) && count($this->json->data->tuples));
 	}
 
 	/**
@@ -144,8 +144,8 @@ class MeterTest extends Data
 		$this->assertFromTo(0, 0);
 		$this->assertHeader(0, 0, 0);
 
-		// tuples
-		$this->assertFalse(isset($this->json->data->tuples));
+		// tuples not set or empty array
+		$this->assertFalse(isset($this->json->data->tuples) && count($this->json->data->tuples));
 	}
 
 	/**

--- a/test/Tests/SensorTest.php
+++ b/test/Tests/SensorTest.php
@@ -34,10 +34,6 @@ class SensorTest extends Data
 		self::$uuid = self::createChannel('Sensor', 'powersensor', self::$resolution);
 	}
 
-	// static function tearDownAfterClass() {
-	// 	echo(" ".self::$uuid);
-	// }
-
 	function getConsumption($from, $to, $periodValue) {
 		return($periodValue * ($to - $from) / 3600000 / self::$resolution);
 	}
@@ -75,8 +71,8 @@ class SensorTest extends Data
 		$this->assertFromTo($this->ts1, $this->ts1);
 		$this->assertHeader(0, 0, 1);
 
-		// tuples
-		$this->assertFalse(isset($this->json->data->tuples));
+		// tuples not set or empty array
+		$this->assertFalse(isset($this->json->data->tuples) && count($this->json->data->tuples));
 	}
 
 	/**
@@ -151,8 +147,8 @@ class SensorTest extends Data
 		$this->assertFromTo(0, 0);
 		$this->assertHeader(0, 0, 0);
 
-		// tuples
-		$this->assertFalse(isset($this->json->data->tuples));
+		// tuples not set or empty array
+		$this->assertFalse(isset($this->json->data->tuples) && count($this->json->data->tuples));
 	}
 
 	/**


### PR DESCRIPTION
Fix #303 

Reduces memory usage by printing large number of tuples directly to output using `Symfony\StreamedResponse` instead of storing as php arrays before being encoded to json.

Requires php 5.4.0 as `StreamedResponse->setCallback()` takes a closure with access to `$this`.