### PR TITLE
Allow chart parameters global override

### DIFF
--- a/htdocs/frontend/javascripts/entities.js
+++ b/htdocs/frontend/javascripts/entities.js
@@ -187,7 +187,7 @@ vz.entities.loadMultipleData = function(entities) {
 		data: {
 			from: Math.floor(vz.options.plot.xaxis.min),
 			to: Math.ceil(vz.options.plot.xaxis.max),
-			tuples: vz.options.tuples,
+			tuples: vz.options.group === undefined ? vz.options.tuples : Number.MAX_SAFE_INTEGER,
 			options: vz.options.options,
 			uuid: entities.map(function(entity) {
 				return entity.uuid;

--- a/htdocs/frontend/javascripts/functions.js
+++ b/htdocs/frontend/javascripts/functions.js
@@ -206,12 +206,12 @@ vz.parseUrlParams = function() {
 						vz.options.plot.xaxis.max = ts;
 					break;
 
+				case 'style': // explicitly set display style
+				case 'fillstyle': // explicitly set fill style
+				case 'linewidth': // explicitly set line width
 				case 'group': // explicitly set data grouping
-					vz.options[key] = vars[key];
-					break;
-
 				case 'options': // data load options
-					vz.options.options = vars[key];
+					vz.options[key] = vars[key];
 					break;
 			}
 		}

--- a/htdocs/frontend/javascripts/wui.js
+++ b/htdocs/frontend/javascripts/wui.js
@@ -751,8 +751,13 @@ vz.wui.drawPlot = function () {
 				return t.slice(0);
 			});
 
+
+			var style = vz.options.style || entity.style;
+			var fillstyle = parseFloat(vz.options.fillstyle || entity.fillstyle);
+			var linewidth = parseFloat(vz.options.linewidth || vz.options[index == vz.wui.selectedChannel ? 'lineWidthSelected' : 'lineWidthDefault']);
+
 			// mangle data for "steps" curves by shifting one ts left ("step-before")
-			if (entity.style == "steps") {
+			if (style == "steps") {
 				tuples.unshift([entity.data.from, 1, 1]); // add new first ts
 				for (i=0; i<tuples.length-1; i++) {
 					tuples[i][1] = tuples[i+1][1];
@@ -760,7 +765,7 @@ vz.wui.drawPlot = function () {
 			}
 
 			// remove number of datapoints from each tuple to avoid flot fill error
-			if (entity.fillstyle || entity.gap) {
+			if (fillstyle || entity.gap) {
 				for (i=0; i<tuples.length; i++) {
 					maxTuples = Math.max(maxTuples, tuples[i][2]);
 					delete tuples[i][2];
@@ -774,13 +779,13 @@ vz.wui.drawPlot = function () {
 				title: entity.title,
 				unit : entity.definition.unit,
 				lines: {
-					show: (entity.style == 'lines' || entity.style == 'steps'),
-					steps: (entity.style == 'steps'),
-					lineWidth: (index == vz.wui.selectedChannel ? vz.options.lineWidthSelected : vz.options.lineWidthDefault),
-					fill: (entity.fillstyle !== undefined) ? entity.fillstyle : false
+					show:       style == 'lines' || style == 'steps',
+					steps:      style == 'steps' || style == 'steps',
+					fill:       fillstyle !== undefined ? fillstyle : false,
+					lineWidth:  linewidth
 				},
 				points: {
-					show: (entity.style == 'points')
+					show:       style == 'points' || style == 'points'
 				},
 				yaxis: entity.assignedYaxis
 			};


### PR DESCRIPTION
Allow to set global options using frontend url:

  - `from` .. `to`: js-formatted timestamps
  - `group`: data grouping, e.g. `day`
  - `style`: display style (line, steps, point), e.g. to display grouped data in `steps`
  - `fillstyle`: numeric fill value between 0 .. 1

Example: 

    http://localhost/frontend/?from=2014-01-01&to=2014-02-01&group=day&style=steps&fillstyle=0.01