### PR TITLE
Add nocache option to disable SQL caching for debugging (MySQL and Sqlite)

### DIFF
--- a/lib/Interpreter/Interpreter.php
+++ b/lib/Interpreter/Interpreter.php
@@ -104,6 +104,10 @@ abstract class Interpreter implements \Iterator {
 		// add db-specific SQL optimizations
 		$class = SQL\SQLOptimizer::factory();
 		$this->optimizer = new $class($this, $this->conn);
+
+		if ($this->hasOption('nocache')) {
+			$this->optimizer->disableCache();
+		}
 	}
 
 	/**
@@ -172,10 +176,6 @@ abstract class Interpreter implements \Iterator {
 			// for the frontend to be able to draw graphs to the left and right borders
 			if (isset($this->from)) {
 				$sql = 'SELECT MAX(timestamp) FROM data WHERE channel_id=? AND timestamp < (SELECT MAX(timestamp) FROM data WHERE channel_id=? AND timestamp<?)';
-				// $sql = 'SELECT IFNULL(' .
-				// 			'SELECT MAX(timestamp) FROM data WHERE channel_id=? AND timestamp < (SELECT MAX(timestamp) FROM data WHERE channel_id=? AND timestamp<?), ' .
-				// 			'SELECT MAX(timestamp) FROM data WHERE channel_id=? AND timestamp<?' .
-				// 	   ')';
 
 				// if not second-highest timestamp take highest before $this->from
 				if (null === $from = $this->conn->fetchColumn($sql, array($this->channel->getId(), $this->channel->getId(), $this->from), 0)) {

--- a/lib/Interpreter/SQL/MySQLOptimizer.php
+++ b/lib/Interpreter/SQL/MySQLOptimizer.php
@@ -35,6 +35,13 @@ use Doctrine\DBAL;
 class MySQLOptimizer extends SQLOptimizer {
 
 	/**
+	 * Disable SQL statement caching
+	 */
+	public function disableCache() {
+		$this->conn->executeQuery('SET SESSION query_cache_type = 0');
+	}
+
+	/**
 	 * DB-specific data grouping by date functions
 	 *
 	 * @param string $groupBy

--- a/lib/Interpreter/SQL/SQLOptimizer.php
+++ b/lib/Interpreter/SQL/SQLOptimizer.php
@@ -166,6 +166,13 @@ class SQLOptimizer {
 		// not implemented
 		return false;
 	}
+
+	/**
+	 * Disable SQL statement caching
+	 */
+	public function disableCache() {
+		throw new \RuntimeException('Disabling caching not implemented for current DBMS');
+	}
 }
 
 ?>

--- a/lib/Interpreter/SQL/SQLiteOptimizer.php
+++ b/lib/Interpreter/SQL/SQLiteOptimizer.php
@@ -30,6 +30,13 @@ namespace Volkszaehler\Interpreter\SQL;
 class SQLiteOptimizer extends SQLOptimizer {
 
 	/**
+	 * Disable SQL statement caching
+	 */
+	public function disableCache() {
+		$this->conn->executeQuery('PRAGMA cache_size = 0');
+	}
+
+	/**
 	 * DB-specific data grouping by date functions
 	 *
 	 * @param string $groupBy

--- a/lib/Util/Debug.php
+++ b/lib/Util/Debug.php
@@ -101,7 +101,9 @@ class Debug {
 	 * Is debugging enabled?
 	 * @return boolean
 	 */
-	public static function isActivated() { return isset(self::$instance); }
+	public static function isActivated() {
+		return isset(self::$instance);
+	}
 
 	/**
 	 * Deactivate debugging (for http server)
@@ -125,21 +127,22 @@ class Debug {
 	/**
 	 * @return float execution time
 	 */
-	public function getExecutionTime() { return round((microtime(TRUE) - $this->created), 5); }
+	public function getExecutionTime() { 
+		return round((microtime(TRUE) - $this->created), 5); 
+	}
 
 	/**
 	 * @return 2 dimensional array with sql queries and parameters
 	 */
-	public function getQueries() { return $this->sqlLogger->queries; }
+	public function getQueries() { 
+		return $this->sqlLogger->queries; 
+	}
 
 	/**
 	 * getParametrizedQuery helper function
 	 */
 	private static function formatSQLParameter($para) {
-		if (is_numeric($para)) {
-			return $para;
-		}
-		elseif (is_string($para)) {
+		if (is_string($para)) {
 			return (strtoupper($para) == 'NULL') ?: "'" . $para . "'";
 		}
 		return $para;
@@ -170,7 +173,9 @@ class Debug {
 	/**
 	 * @return integer current debug level
 	 */
-	 public function getLevel() { return $this->level; }
+	public function getLevel() {
+		return $this->level;
+	}
 
 	/**
 	 * Fail-safe, non-warning, portable shell_exec

--- a/lib/View/JSON.php
+++ b/lib/View/JSON.php
@@ -331,7 +331,13 @@ class JSON extends View {
 			$jsonDebug['sql'] = array(
 				'totalTime' => $this->sqlTotalTime,
 				'worstTime' => $this->sqlWorstTime,
-				'queries' => array_values($debug->getQueries())
+				'queries' =>
+					array_map(function($q) {
+						return array(
+							'sql' => Util\Debug::getParametrizedQuery($q['sql'], $q['params']),
+							'execTime' => $q['executionMS']
+						);
+					}, array_values($debug->getQueries()))
 			);
 		}
 


### PR DESCRIPTION
Provide better debugging capabilities. Allows re-running SQL queries while eliminating cache impacts.