### PR TITLE
Add working hours sensor

### DIFF
--- a/lib/Definition/EntityDefinition.json
+++ b/lib/Definition/EntityDefinition.json
@@ -302,8 +302,22 @@
 		"hasConsumption"	: true,
 		"translation"		: {
 			"de" : "Betriebsstundenzähler",
-			"en" : "Working Hour Meter",
+			"en" : "Operation Hours Meter",
 			"fr" : "Compteur horaire"
+		}
+	},
+	{
+		"name"			: "workinghourssensor",
+		"required"		: ["resolution"],
+		"optional"		: ["tolerance", "local"],
+		"icon"			: "clock.png",
+		"unit"			: "",
+		"scale"			: 1000,
+		"interpreter"		: "Volkszaehler\\Interpreter\\SensorInterpreter",
+		"model"			: "Volkszaehler\\Model\\Channel",
+		"hasConsumption"	: true,
+		"translation"		: {
+			"de" : "Betriebsstundensensor"
 		}
 	},
 	{


### PR DESCRIPTION
Used for logging devices sending 0/1 to indicate operations, basically similar to a valve but with consumption.