### PR TITLE
Fix matching entity middleware with middleware definition

### DIFF
--- a/htdocs/frontend/javascripts/entities.js
+++ b/htdocs/frontend/javascripts/entities.js
@@ -166,7 +166,7 @@ vz.entities.loadData = function() {
 	vz.middleware.each(function(idx, middleware) {
 		var entities = [];
 		vz.entities.each(function(entity) {
-			if (entity.middleware == middleware.url && entity.hasData()) {
+			if (entity.hasData() && entity.middleware.indexOf(middleware.url) >= 0) {
 				entities.push(entity);
 			}
 		}, true); // recursive

--- a/htdocs/frontend/javascripts/functions.js
+++ b/htdocs/frontend/javascripts/functions.js
@@ -45,7 +45,7 @@ vz.getLink = function(format) {
 			if (entities.length === 0) {
 				middleware = entity.middleware;
 			}
-			if (entity.middleware == middleware) {
+			if (entity.middleware.indexOf(middleware) >= 0) {
 				entities.push(entity);
 			}
 			else {

--- a/htdocs/frontend/javascripts/init.js
+++ b/htdocs/frontend/javascripts/init.js
@@ -157,7 +157,7 @@ $(document).ready(function() {
 
 					// subscribe entities
 					vz.entities.each(function(entity) {
-						if (entity.active && entity.middleware == middleware.url) {
+						if (entity.active && entity.middleware.indexOf(middleware.url) >= 0) {
 							entity.subscribe(session);
 						}
 					}, true);


### PR DESCRIPTION
Fix an interesting issue where middleware definition with a pattern like `//demo.vz.org` does not match middleware as stored in entity with pattern of `http://demo.vz.org`.

May fix https://github.com/volkszaehler/volkszaehler.org/issues/387