### PR TITLE
Revert batching middleware operations

### DIFF
--- a/htdocs/frontend/javascripts/functions.js
+++ b/htdocs/frontend/javascripts/functions.js
@@ -138,9 +138,8 @@ vz.load = function(args) {
 	return $.ajax(args).then(function(json) {
 		// success
 		if (json.exception) {
-			// handle json exceptions sent with HTTP status 200
-			vz.wui.dialogs.exception(new Exception(json.exception.type, args.url + ':<br/><br/>' + json.exception.message));
-			return $.Deferred().reject();
+			// raise json exceptions sent with HTTP status 200
+			return $.Deferred().rejectWith(this, [json]);
 		}
 		return $.Deferred().resolveWith(this, [json]);
 	}, function(xhr) {

--- a/htdocs/frontend/javascripts/init.js
+++ b/htdocs/frontend/javascripts/init.js
@@ -125,7 +125,7 @@ $(document).ready(function() {
 
 			vz.entities.loadData().done(function() {
 				vz.wui.drawPlot();
-				vz.entities.loadTotals();
+				vz.entities.loadTotalConsumption();
 			});
 
 			// create WAMP sessions for each middleware

--- a/htdocs/frontend/javascripts/wui.js
+++ b/htdocs/frontend/javascripts/wui.js
@@ -121,8 +121,11 @@ vz.wui.addEntity = function(entity) {
 	vz.entities.push(entity);
 	vz.entities.saveCookie();
 	vz.entities.showTable();
-	vz.entities.loadData().done(vz.wui.drawPlot);
 	vz.options.plot.axesAssigned = false; // force axis assignment
+	entity.loadData().done(function() {
+		vz.wui.drawPlot();
+		entity.loadTotalConsumption();
+	});
 };
 
 /**


### PR DESCRIPTION
Remove code for batching middleware requests. Should no longer be a big performance issue and should in total make the frontend feel a little more agile.