### PR TITLE
Fix HTTP 400 not sent on exceptions when using JSON

### DIFF
--- a/htdocs/frontend/javascripts/entities.js
+++ b/htdocs/frontend/javascripts/entities.js
@@ -65,13 +65,13 @@ vz.entities.loadCookie = function() {
 vz.entities.loadDetails = function() {
 	var queue = [];
 	vz.entities.each(function(entity) {
-		queue.push(entity.loadDetails().fail(function(json) {
-			console.error(json);
+		// skip default error handling
+		queue.push(entity.loadDetails(true).fail(function(json) {
 			if (json.exception && json.exception.message && json.exception.message.match(/^Invalid UUID/)) {
 				vz.entities.remove(entity);
 				return;
 			}
-			throw json.exception.message;
+			vz.wui.middlewareException(json.exception);
 		}));
 	}, true); // recursive
 	return $.when.apply($, queue);

--- a/htdocs/frontend/javascripts/entity.js
+++ b/htdocs/frontend/javascripts/entity.js
@@ -263,14 +263,14 @@ Entity.prototype.dataUpdated = function(data) {
  * Query middleware for details
  * @return jQuery dereferred object
  */
-Entity.prototype.loadDetails = function() {
+Entity.prototype.loadDetails = function(skipDefaultErrorHandling) {
 	delete this.children; // clear children first
 	return vz.load({
 		url: this.middleware,
 		controller: 'entity',
 		identifier: this.uuid,
 		context: this
-	}).done(function(json) {
+	}, skipDefaultErrorHandling).done(function(json) {
 		this.parseJSON(json.entity);
 	});
 };

--- a/htdocs/frontend/javascripts/wui.js
+++ b/htdocs/frontend/javascripts/wui.js
@@ -921,3 +921,11 @@ vz.wui.dialogs.exception = function(exception) {
 	if (vz.wui.errorDialog) return;
 	this.error(exception.type, exception.message, exception.code);
 };
+
+vz.wui.dialogs.middlewareException = function(exception, url) {
+	var msg = exception.message;
+	if (url) {
+		msg = "<a href='" + url + "' style='text-decoration:none'>" + url + "</a>:<br/><br/>" + msg;
+	}
+	this.exception(new Exception("Middleware Error (" + exception.type + ")", msg));
+};

--- a/lib/Router.php
+++ b/lib/Router.php
@@ -53,11 +53,6 @@ class Router implements HttpKernelInterface {
 	public $em;
 
 	/**
-	 * @var Util\Debug optional debugging instance
-	 */
-	public $debug;
-
-	/**
 	 * @var View\View output view
 	 */
 	public $view;
@@ -154,6 +149,17 @@ class Router implements HttpKernelInterface {
 			}
 		}
 
+		// initialize debugging
+		if (($debugLevel = $request->query->get('debug')) || $debugLevel = Util\Configuration::read('debug')) {
+			if ($debugLevel > 0 && !Util\Debug::isActivated()) {
+				new Util\Debug($debugLevel, $this->em);
+			}
+		}
+		else {
+			// make sure static debug instance is removed
+			Util\Debug::deactivate();
+		}
+
 		$class = self::$viewMapping[$format];
 		$this->view = new $class($request, $format);
 
@@ -174,17 +180,6 @@ class Router implements HttpKernelInterface {
 	 * Example: http://sub.domain.local/middleware.php/channel/550e8400-e29b-11d4-a716-446655440000/data.json?operation=edit&title=New Title
 	 */
 	function handler(Request $request, $context, $uuid) {
-		// initialize debugging
-		if (($debugLevel = $request->query->get('debug')) || $debugLevel = Util\Configuration::read('debug')) {
-			if ($debugLevel > 0) {
-				$this->debug = new Util\Debug($debugLevel, $this->em);
-			}
-		}
-		else {
-			// make sure static debug instance is removed
-			Util\Debug::deactivate();
-		}
-
 		// get controller operation
 		if (null === ($operation = $request->query->get('operation'))) {
 			$operation = self::$operationMapping[strtolower($request->getMethod())];

--- a/lib/Util/Debug.php
+++ b/lib/Util/Debug.php
@@ -60,7 +60,7 @@ class Debug {
 		$this->em = $em;
 		$this->attachSqlLogger(new Logging\DebugStack());
 
-		if (isset(self::$instance)) {
+		if (self::isActivated()) {
 			throw new \Exception('Debugging has already been started. Please use the static functions!');
 		}
 		self::$instance = $this;
@@ -135,7 +135,7 @@ class Debug {
 	 * @return 2 dimensional array with sql queries and parameters
 	 */
 	public function getQueries() { 
-		return $this->sqlLogger->queries; 
+		return ($this->sqlLogger) ? $this->sqlLogger->queries : array();
 	}
 
 	/**

--- a/lib/View/JSON.php
+++ b/lib/View/JSON.php
@@ -60,14 +60,6 @@ class JSON extends View {
 		parent::__construct($request);
 
 		$this->json = array('version' => VZ_VERSION);
-
-		$this->padding = $request->query->get('padding');
-	}
-
-	/**
-	 * Render response and send it to the client
-	 */
-	public function send() {
 		// use StreamedResponse unless pretty-printing is required
 		if (Util\Debug::isActivated()) {
 			$this->add(Util\Debug::getInstance());
@@ -75,6 +67,8 @@ class JSON extends View {
 		else {
 			$this->response = new StreamedResponse();
 		}
+
+		$this->padding = $request->query->get('padding');
 
 		// JSONP
 		if ($this->padding) {
@@ -85,7 +79,12 @@ class JSON extends View {
 			// enable CORS if not JSONP
 			$this->response->headers->set('Access-Control-Allow-Origin', '*');
 		}
+	}
 
+	/**
+	 * Render response and send it to the client
+	 */
+	public function send() {
 		if ($this->response instanceof StreamedResponse) {
 			$this->response->setCallback(function() {
 				$this->renderDeferred();


### PR DESCRIPTION
While JSONP requires HTTP 200 in order to be interpreted by client, JSON should return HTTP 400 on exceptions.

This is already implemented in https://github.com/volkszaehler/volkszaehler.org/blob/master/lib/View/JSON.php#L119 however not working due to the response getting overwritten in https://github.com/volkszaehler/volkszaehler.org/blob/master/lib/View/JSON.php#L76.