### PR TITLE
Add config setting for maximum allowed POST size

### DIFF
--- a/etc/volkszaehler.conf.template.php
+++ b/etc/volkszaehler.conf.template.php
@@ -112,6 +112,11 @@ $config['push']['routes']['wamp'] = array('/', '/ws');		// routes for wamp acces
 $config['push']['routes']['websocket'] = array();			// routes for plain web sockets, try array('/socket')
 
 /**
+ * Security settings
+ */
+$config['security']['maxbodysize'] = false;	// limit maximum POST body size, e.g. 4096
+
+/**
  * Timezone for the middleware
  *
  * See PHP doc for details: http://www.php.net/manual/de/timezones.php

--- a/lib/Controller/DataController.php
+++ b/lib/Controller/DataController.php
@@ -85,6 +85,14 @@ class DataController extends Controller {
 
 		try { /* to parse new submission protocol */
 			$rawPost = $this->request->getContent(); // file_get_contents('php://input')
+
+			// check maximum size allowed
+			if ($maxSize = Util\Configuration::read('security.maxbodysize')) {
+				if (strlen($rawPost) > $maxSize) {
+					throw new \Exception('Maximum message size exceeded');
+				}
+			}
+
 			$json = Util\JSON::decode($rawPost);
 
 			if (isset($json['data'])) {


### PR DESCRIPTION
Help prevent DoS scenarios by not handing large payloads to json decode or even database.