### PR TITLE
Update PropertyDefinition.json / Frontend -> Kanal -> Kosten : negative Werte nicht möglich

### DIFF
--- a/lib/Definition/PropertyDefinition.json
+++ b/lib/Definition/PropertyDefinition.json
@@ -65,7 +65,6 @@
 	{
 		"name"			: "cost",
 		"type"			: "float",
-		"min"			: 0,
 		"translation"		: {
 			"de" : "Kosten",
 			"en" : "Costs"


### PR DESCRIPTION
Für eine Einspeisevergütung möchte man keine positiven sondern negative Kosten im Frontend sehen.
Damit man einen negativen Kostenfaktor eingeben kann, muss für den Parameter "cost" die "min" Begrenzung entfallen.

Verbrauch (z.B. Herd) und Erzeugung (z.B. PV-Anlage) haben dann unterschiedliche Vorzeichen in der Spalte "Kosten".