### PR TITLE
Improve interpreters internal naming

### DIFF
--- a/lib/Definition/EntityDefinition.json
+++ b/lib/Definition/EntityDefinition.json
@@ -63,7 +63,7 @@
 		"icon"			: "bolt.png",
 		"unit"			: "W",
 		"scale"			: 1000,
-		"interpreter"		: "Volkszaehler\\Interpreter\\MeterInterpreter",
+		"interpreter"		: "Volkszaehler\\Interpreter\\ImpulseInterpreter",
 		"model"			: "Volkszaehler\\Model\\Channel",
 		"hasConsumption"	: true,
 		"translation"		: {
@@ -93,7 +93,7 @@
 		"icon"			: "bolt.png",
 		"unit"			: "W",
 		"scale"			: 1000,
-		"interpreter"		: "Volkszaehler\\Interpreter\\CounterInterpreter",
+		"interpreter"		: "Volkszaehler\\Interpreter\\AccumulatorInterpreter",
 		"style"			: "steps",
 		"model"			: "Volkszaehler\\Model\\Channel",
 		"hasConsumption"	: true,
@@ -134,7 +134,7 @@
 		"optional"		: ["tolerance", "cost", "local", "initialconsumption"],
 		"icon"			: "flame.png",
 		"unit"			: "m³/h",
-		"interpreter"		: "Volkszaehler\\Interpreter\\MeterInterpreter",
+		"interpreter"		: "Volkszaehler\\Interpreter\\ImpulseInterpreter",
 		"model"			: "Volkszaehler\\Model\\Channel",
 		"hasConsumption"	: true,
 		"translation"		: {
@@ -149,7 +149,7 @@
 		"optional"		: ["tolerance", "cost", "local", "initialconsumption"],
 		"icon"			: "flame.png",
 		"unit"			: "m³/h",
-		"interpreter"		: "Volkszaehler\\Interpreter\\CounterInterpreter",
+		"interpreter"		: "Volkszaehler\\Interpreter\\AccumulatorInterpreter",
 		"model"			: "Volkszaehler\\Model\\Channel",
 		"hasConsumption"	: true,
 		"translation"		: {
@@ -164,7 +164,7 @@
 		"icon"			: "flame.png",
 		"unit"			: "W",
 		"scale"			: 1000,
-		"interpreter"		: "Volkszaehler\\Interpreter\\MeterInterpreter",
+		"interpreter"		: "Volkszaehler\\Interpreter\\ImpulseInterpreter",
 		"model"			: "Volkszaehler\\Model\\Channel",
 		"hasConsumption"	: true,
 		"translation"		: {
@@ -207,7 +207,7 @@
 		"optional"		: ["tolerance", "cost", "local", "initialconsumption"],
 		"icon"			: "waterdrop.png",
 		"unit"			: "l/h",
-		"interpreter"		: "Volkszaehler\\Interpreter\\MeterInterpreter",
+		"interpreter"		: "Volkszaehler\\Interpreter\\ImpulseInterpreter",
 		"model"			: "Volkszaehler\\Model\\Channel",
 		"hasConsumption"	: true,
 		"translation"		: {
@@ -236,7 +236,7 @@
 		"optional"		: ["tolerance", "local"],
 		"icon"			: "clock.png",
 		"unit"			: "h",
-		"interpreter"		: "Volkszaehler\\Interpreter\\MeterInterpreter",
+		"interpreter"		: "Volkszaehler\\Interpreter\\ImpulseInterpreter",
 		"model"			: "Volkszaehler\\Model\\Channel",
 		"hasConsumption"	: true,
 		"translation"		: {
@@ -251,7 +251,7 @@
 		"optional"		: ["tolerance", "local", "initialconsumption"],
 		"icon"			: "clock.png",
 		"unit"			: "h",
-		"interpreter"		: "Volkszaehler\\Interpreter\\CounterInterpreter",
+		"interpreter"		: "Volkszaehler\\Interpreter\\AccumulatorInterpreter",
 		"model"			: "Volkszaehler\\Model\\Channel",
 		"hasConsumption"	: true,
 		"translation"		: {

--- a/lib/Definition/README.md
+++ b/lib/Definition/README.md
@@ -27,7 +27,7 @@ Is `true` if a physical entity supports integration over time.
 
 ### initialconsumption
 
-Initial consumption can be set to define how much consumption a channel has accumulated before measurement in volkszaehler has started. For channels using `CounterInterpreter` hat value is actually stored in the database, but not easily accessible by the middleware. Using `initialconsumption` instead any arbitrary value can be used as starting point. Unit for initialconsumption is the base unit (scaled according to `scale`) converted to an hourly consumption.
+Initial consumption can be set to define how much consumption a channel has accumulated before measurement in volkszaehler has started. For channels using `AccumulatorInterpreter` hat value is actually stored in the database, but not easily accessible by the middleware. Using `initialconsumption` instead any arbitrary value can be used as starting point. Unit for initialconsumption is the base unit (scaled according to `scale`) converted to an hourly consumption.
 
 ## Examples
 
@@ -41,12 +41,12 @@ Initial consumption can be set to define how much consumption a channel has accu
 		"unit"			: "W",
 		"scale"			: 1000,
 		"hasConsumption"	: true,
-		"interpreter"		: "Volkszaehler\\Interpreter\\CounterInterpreter",
+		"interpreter"		: "Volkszaehler\\Interpreter\\AccumulatorInterpreter",
 		...
 	}
 ````
 
-Defines a channel type of `electric meter` that is measured in W. Unit `scale` is 1000, that is kW. As it uses `CounterInterpreter`, the readings are in impulses/ticks/counts per consumption unit:
+Defines a channel type of `electric meter` that is measured in W. Unit `scale` is 1000, that is kW. As it uses `AccumulatorInterpreter`, the readings are in impulses/ticks/counts per consumption unit:
 
   - `resolution`: impulses per kWh (accoding to `scale`)
   - `cost`: cost in € per per kWh (again accoding to `scale`)
@@ -60,11 +60,11 @@ Defines a channel type of `electric meter` that is measured in W. Unit `scale` i
 		"required"		: ["resolution"],
 		"optional"		: ["tolerance", "cost", "local", "initialconsumption"],
 		"unit"			: "m³/h",
-		"interpreter"		: "Volkszaehler\\Interpreter\\MeterInterpreter",
+		"interpreter"		: "Volkszaehler\\Interpreter\\ImpulseInterpreter",
 		"hasConsumption"	: true,
 ````
 
-Defines a channel type of `gas` that is measured in m³/h. Unit `scale` is not defined and therefore defaults to 1. As it uses `MeterInterpreter`, the readings are consumption values:
+Defines a channel type of `gas` that is measured in m³/h. Unit `scale` is not defined and therefore defaults to 1. As it uses `ImpulseInterpreter`, the readings are consumption values:
 
   - `resolution`: impulses per m³
   - `cost`: cost in € per per m³

--- a/lib/Interpreter/AccumulatorInterpreter.php
+++ b/lib/Interpreter/AccumulatorInterpreter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Copyright (c) 2011, The volkszaehler.org project
+ * @copyright Copyright (c) 2012, The volkszaehler.org project
  * @package default
  * @license http://www.opensource.org/licenses/gpl-license.php GNU Public License
  */
@@ -24,17 +24,19 @@
 namespace Volkszaehler\Interpreter;
 
 /**
- * Meter interpreter
+ * Counter interpreter
  *
  * @package default
- * @author Steffen Vogel <info@steffenvogel.de>
+ * @author Jakob Hirsch <jh.vz@plonk.de>
  * @author Andreas Götz <cpuidle@gmx.de>
  */
 
-class MeterInterpreter extends Interpreter {
+class AccumulatorInterpreter extends Interpreter {
 
-	protected $pulseCount;
-	protected $ts_last; // previous tuple timestamp
+	protected $ts_last; 	// previous tuple timestamp
+	protected $last_val; 	// previous tuple value
+	protected $delta_val; 	// previous tuple delta
+	protected $valsum;		// sum of delta values
 
 	/**
 	 * Initialize data iterator
@@ -44,8 +46,13 @@ class MeterInterpreter extends Interpreter {
 		$this->rows = $this->getData();
 		$this->rows->rewind();
 
-		$this->pulseCount = 0;
-		$this->ts_last = $this->getFrom();
+		$this->valsum = 0;
+
+		// get starting value from skipped first row
+		if ($this->rowCount > 0) {
+			$this->ts_last = $this->getFrom();
+			$this->last_val = $this->rows->firstValue();
+		}
 	}
 
 	/**
@@ -60,7 +67,7 @@ class MeterInterpreter extends Interpreter {
 		}
 
 		$tuple = $this->convertRawTuple($row);
-		$this->pulseCount += $row[1];
+		$this->valsum += $this->delta_val;
 
 		if (is_null($this->max) || $tuple[1] > $this->max[1]) {
 			$this->max = $tuple;
@@ -77,12 +84,18 @@ class MeterInterpreter extends Interpreter {
 	 * Convert raw meter readings
 	 */
 	public function convertRawTuple($row) {
-		$delta = $row[0] - $this->ts_last;
+		$delta_ts = $row[0] - $this->ts_last; // time between now and row before
 
-		// (1 imp * 60 min/h * 60 s/min * 1000 ms/s * scale) / (1 imp/kWh * 1ms) = 3.6e6 kW
+		// instead of reverting what DataIterator->next did when packaging by $val = $row[1] / $row[2]
+		// get max value which DataIterator->next provides as courtesy
+		$value = isset($row[3]) ? $row[3] : $row[1];
+		$this->delta_val = $value - $this->last_val;
+		$this->last_val = $value;
+
+		// (1 imp / 1 imp/kWh) * (60 min/h * 60 s/min * 1000 ms/s * scale) / 1 ms
 		$tuple = array(
 			(float) ($this->ts_last = $row[0]), // timestamp of interval end
-			(float) ($row[1] * 3.6e6 * $this->scale) / ($this->resolution * $delta), // doing df/dt
+			(float) ($this->delta_val * 3.6e6 * $this->scale) / ($delta_ts * $this->resolution), // doing df/dt
 			(int) $row[2] // num of rows
 		);
 
@@ -95,7 +108,7 @@ class MeterInterpreter extends Interpreter {
 	 * @return float total consumption in Wh
 	 */
 	public function getConsumption() {
-		return $this->channel->getDefinition()->hasConsumption ? $this->scale * $this->pulseCount / $this->resolution : NULL;
+		return $this->channel->getDefinition()->hasConsumption ? $this->valsum * $this->scale / $this->resolution : NULL;
 	}
 
 	/**
@@ -104,10 +117,10 @@ class MeterInterpreter extends Interpreter {
 	 * @return float average in W
 	 */
 	public function getAverage() {
-		if ($this->pulseCount) {
+		if ($this->valsum) {
 			$delta = $this->getTo() - $this->getFrom();
-			// 60 s/min * 60 min/h * 1.000 ms/s * 1.000 W/kW = 3.6e9 (Units: s/h*ms/s*W/KW = s/3.600s*.001s/s*W/1.000W = 1)
-			return (3.6e6 * $this->scale * $this->pulseCount) / ($this->resolution * $delta);
+			// 60 s/min * 60 min/h * 1.000 ms/s * 1.000 W/kW = 3.6e9 (Units: s/h*ms/s*W/kW = s/3.600s*.001s/s*W/1.000W = 1)
+			return (3.6e6 * $this->scale * $this->valsum) / ($this->resolution * $delta);
 		}
 		else { // prevents division by zero
 			return 0;
@@ -120,14 +133,14 @@ class MeterInterpreter extends Interpreter {
 	 * Override Interpreter->groupExpr
 	 *
 	 * For precision when bundling tuples into packages
-	 * CounterInterpreter needs MAX instead of SUM.
+	 * AccumulatorInterpreter needs MAX instead of SUM.
 	 *
 	 * @author Andreas Götz <cpuidle@gmx.de>
 	 * @param string $expression sql parameter
 	 * @return string grouped sql expression
 	 */
 	public static function groupExprSQL($expression) {
-		return 'SUM(' . $expression . ')';
+		return 'MAX(' . $expression . ')';
 	}
 }
 

--- a/lib/Interpreter/DataIterator.php
+++ b/lib/Interpreter/DataIterator.php
@@ -94,7 +94,7 @@ class DataIterator implements \Iterator, \Countable {
 			$package[2] += $tuple[2];
 
 			// special cases - auxilary information for specific interpreters
-			$package[3] = max($package[3], $tuple[1]);						// CounterInterpreter
+			$package[3] = max($package[3], $tuple[1]);						// AccumulatorInterpreter
 			$package[4] += $tuple[1] * ($tuple[0] - $this->lastTimestamp);	// SensorInterpreter
 
 			$this->lastTimestamp = $tuple[0];

--- a/lib/Server/MiddlewareAdapter.php
+++ b/lib/Server/MiddlewareAdapter.php
@@ -102,8 +102,8 @@ class MiddlewareAdapter {
 			}
 			// prevent div by zero
 			elseif ($tuple[0] > $interpreter->push_ts) {
-				// CounterInterpreter special handling- suppress duplicate counter values
-				if ($interpreter instanceof Interpreter\CounterInterpreter) {
+				// AccumulatorInterpreter special handling- suppress duplicate counter values
+				if ($interpreter instanceof Interpreter\AccumulatorInterpreter) {
 					if (isset($interpreter->push_raw_value) && $interpreter->push_raw_value == $tuple[1]) {
 						return false;
 					}

--- a/lib/View/JpGraph.php
+++ b/lib/View/JpGraph.php
@@ -193,7 +193,7 @@ class JpGraph extends View {
 
 			$plot->setLegend($interpreter->getEntity()->getProperty('title') . ':  [' . $interpreter->getEntity()->getDefinition()->getUnit() . ']');
 			$plot->SetColor($this->colors[$this->count]);
-			$plot->SetStepStyle($interpreter instanceof Interpreter\MeterInterpreter);
+			$plot->SetStepStyle($interpreter instanceof Interpreter\ImpulseInterpreter);
 
 			$axis = $this->getAxisIndex($interpreter->getEntity());
 			if ($axis >= 0) {

--- a/test/AccumulatorTest.php
+++ b/test/AccumulatorTest.php
@@ -8,7 +8,7 @@
 
 namespace Tests;
 
-class CounterTest extends Data
+class AccumulatorTest extends Data
 {
 	// channel properties
 	static $resolution = 100;

--- a/test/ImpulseTest.php
+++ b/test/ImpulseTest.php
@@ -8,7 +8,7 @@
 
 namespace Tests;
 
-class MeterTest extends Data
+class ImpulseTest extends Data
 {
 	// channel properties
 	static $resolution = 100;


### PR DESCRIPTION
Fix #415 

**Breaking change** the naming of the Interpreters in `EntityDefinition.json` changes. This will affect *anybody* who has created custom entity types:

  - `SensorInterpreter` -> `SensorInterpreter` (as is)
  - `MeterInterpreter` -> `ImpulseInterpreter`
  - `CounterInterpreter` -> `AccumulatorInterpreter`
