### PR TITLE
Add chart style "switches"

### DIFF
--- a/htdocs/frontend/javascripts/wui.js
+++ b/htdocs/frontend/javascripts/wui.js
@@ -502,6 +502,13 @@ vz.wui.updateLegend = function() {
 				y = p[1];
 			else
 				y = null;
+		} else if (series.lines.switches) {
+			y = null;
+			if (j < series.data.length) {				
+				var p2 = series.data[j];
+				if (p2)
+					y = p2[1];
+			}
 		} else { // no steps -> interpolate
 			var p1 = series.data[j - 1], p2 = series.data[j];
 			if (p1 == null || p2 == null) // jshint ignore:line
@@ -837,13 +844,13 @@ vz.wui.drawPlot = function () {
 				title: entity.title,
 				unit : entity.definition.unit,
 				lines: {
-					show:       style == 'lines' || style == 'steps',
-					steps:      style == 'steps' || style == 'steps',
+					show:       style == 'lines' || style == 'steps' || style == 'switches',
+					steps:      style == 'steps' || style == 'switches',
 					fill:       fillstyle !== undefined ? fillstyle : false,
 					lineWidth:  linewidth
 				},
 				points: {
-					show:       style == 'points' || style == 'points'
+					show:       style == 'points'
 				},
 				yaxis: entity.assignedYaxis
 			};

--- a/htdocs/frontend/javascripts/wui.js
+++ b/htdocs/frontend/javascripts/wui.js
@@ -502,7 +502,7 @@ vz.wui.updateLegend = function() {
 				y = p[1];
 			else
 				y = null;
-		} else if (series.lines.switches) {
+		} else if (series.lines.states) {
 			y = null;
 			if (j < series.data.length) {				
 				var p2 = series.data[j];
@@ -844,8 +844,8 @@ vz.wui.drawPlot = function () {
 				title: entity.title,
 				unit : entity.definition.unit,
 				lines: {
-					show:       style == 'lines' || style == 'steps' || style == 'switches',
-					steps:      style == 'steps' || style == 'switches',
+					show:       style == 'lines' || style == 'steps' || style == 'states',
+					steps:      style == 'steps' || style == 'states',
 					fill:       fillstyle !== undefined ? fillstyle : false,
 					lineWidth:  linewidth
 				},

--- a/lib/Definition/EntityDefinition.json
+++ b/lib/Definition/EntityDefinition.json
@@ -270,7 +270,7 @@
 		"unit"			: "",
 		"scale"			: 1000,
 		"interpreter"		: "Volkszaehler\\Interpreter\\SensorInterpreter",
-		"style"			: "switches",
+		"style"			: "states",
 		"model"			: "Volkszaehler\\Model\\Channel",
 		"hasConsumption"	: true,
 		"translation"		: {

--- a/lib/Definition/EntityDefinition.json
+++ b/lib/Definition/EntityDefinition.json
@@ -64,6 +64,7 @@
 		"unit"			: "W",
 		"scale"			: 1000,
 		"interpreter"		: "Volkszaehler\\Interpreter\\ImpulseInterpreter",
+		"style"			: "steps",
 		"model"			: "Volkszaehler\\Model\\Channel",
 		"hasConsumption"	: true,
 		"translation"		: {
@@ -78,7 +79,6 @@
 		"unit"			: "W",
 		"scale"			: 1000,
 		"interpreter"		: "Volkszaehler\\Interpreter\\SensorInterpreter",
-		"style"			: "steps",
 		"model"			: "Volkszaehler\\Model\\Channel",
 		"hasConsumption"	: true,
 		"translation"		: {
@@ -135,6 +135,7 @@
 		"icon"			: "flame.png",
 		"unit"			: "m³/h",
 		"interpreter"		: "Volkszaehler\\Interpreter\\ImpulseInterpreter",
+		"style"			: "steps",
 		"model"			: "Volkszaehler\\Model\\Channel",
 		"hasConsumption"	: true,
 		"translation"		: {
@@ -150,6 +151,7 @@
 		"icon"			: "flame.png",
 		"unit"			: "m³/h",
 		"interpreter"		: "Volkszaehler\\Interpreter\\AccumulatorInterpreter",
+		"style"			: "steps",
 		"model"			: "Volkszaehler\\Model\\Channel",
 		"hasConsumption"	: true,
 		"translation"		: {
@@ -268,6 +270,7 @@
 		"unit"			: "",
 		"scale"			: 1000,
 		"interpreter"		: "Volkszaehler\\Interpreter\\SensorInterpreter",
+		"style"			: "switches",
 		"model"			: "Volkszaehler\\Model\\Channel",
 		"hasConsumption"	: true,
 		"translation"		: {

--- a/lib/Definition/PropertyDefinition.json
+++ b/lib/Definition/PropertyDefinition.json
@@ -383,7 +383,7 @@
 		"options"		: [
 			"lines",
 			"steps",
-			"switches",
+			"states",
 			"points"
 		],
 		"translation"		: {

--- a/lib/Definition/PropertyDefinition.json
+++ b/lib/Definition/PropertyDefinition.json
@@ -383,6 +383,7 @@
 		"options"		: [
 			"lines",
 			"steps",
+			"switches",
 			"points"
 		],
 		"translation"		: {

--- a/misc/tools/model_helper.php
+++ b/misc/tools/model_helper.php
@@ -76,14 +76,19 @@ class ValidateCommand extends Command {
 			echo("\n== " . $group . " ==\n");
 
 			foreach($entities as $entity) {
-				echo(str_pad($entity->getName() . ":", 16));
+				$name = $entity->getName();
+				echo(str_pad($name . ":", 20));
+
+				$value = (isset($entity->$property)) ? $entity->$property : '';
 
 				if (in_array($property, $entity->required))
-					echo("required\n");
+					$required = "required";
 				elseif (in_array($property, $entity->optional))
-					echo("optional\n");
+					$required = "optional";
 				else
-					echo("not allowed\n");
+					$required = "not allowed";
+
+				printf("%s\t%s\n", $required, $value);
 			}
 
 			echo("\n");


### PR DESCRIPTION
Fix https://github.com/volkszaehler/volkszaehler.org/issues/338 by adding new chart style "switches". Switches is equal to steps but displays the step after the measurement instead of before. In that respect it is similar to a "switch" event.

Comments on the name are welcome.