### PR TITLE
Enable CORS pre-flight requests

### DIFF
--- a/lib/View/JSON.php
+++ b/lib/View/JSON.php
@@ -67,6 +67,7 @@ class JSON extends View {
 		// add JSON headers
 		$this->response->headers->set('Content-Type', 'application/json');
 		$this->response->headers->set('Access-Control-Allow-Origin', '*');
+		$this->response->headers->set('Access-Control-Allow-Headers', 'Authorization');
 	}
 
 	/**


### PR DESCRIPTION
Required to prevent HTTP errors when using Authorization header