### PR TITLE
Use HTTP methods by default

### DIFF
--- a/htdocs/frontend/javascripts/entity.js
+++ b/htdocs/frontend/javascripts/entity.js
@@ -400,7 +400,7 @@ Entity.prototype.showDetails = function() {
 								identifier: entity.uuid,
 								url: entity.middleware,
 								data: properties,
-								type: 'PULL', // edit
+								method: 'PATCH', // edit
 							}).done(function(json) {
 								entity.parseJSON(json.entity); // update entity
 								try {
@@ -752,7 +752,7 @@ Entity.prototype.delete = function() {
 		context: this,
 		identifier: this.uuid,
 		url: this.middleware,
-		type: 'DELETE'
+		method: 'DELETE'
 	});
 };
 
@@ -768,7 +768,7 @@ Entity.prototype.addChild = function(child) {
 		controller: 'group',
 		identifier: this.uuid,
 		url: this.middleware,
-		type: 'POST',
+		method: 'POST',
 		data: {
 			uuid: child.uuid
 		}
@@ -789,7 +789,7 @@ Entity.prototype.removeChild = function(child) {
 		controller: 'group',
 		identifier: this.uuid,
 		url: this.middleware,
-		type: 'DELETE',
+		method: 'DELETE',
 		data: {
 			uuid: child.uuid
 		}

--- a/htdocs/frontend/javascripts/functions.js
+++ b/htdocs/frontend/javascripts/functions.js
@@ -117,18 +117,6 @@ vz.load = function(args, skipDefaultErrorHandling) {
 		args.data = { };
 	}
 
-	if (args.type) {
-		var operationMapping = {
-			post:	'add',
-			delete:	'delete',
-			get:	'get',
-			pull:	'edit'
-		};
-
-		args.data.operation = operationMapping[args.type.toLowerCase()];
-		delete args.type; // this makes jquery append the data to the query string
-	}
-
 	return $.ajax(args).then(
 		// success - no changes needed
 		null,

--- a/htdocs/frontend/javascripts/wui.js
+++ b/htdocs/frontend/javascripts/wui.js
@@ -280,7 +280,7 @@ vz.wui.dialogs.init = function() {
 			controller: (def.model == 'Volkszaehler\\Model\\Channel') ? 'channel' : 'aggregator',
 			url: $('#entity-create-middleware').val(),
 			data: properties,
-			type: 'POST'
+			method: 'POST'
 		}).done(function(json) {
 			var entity = new Entity(json.entity, $('#entity-create-middleware').val());
 

--- a/lib/Controller/AggregatorController.php
+++ b/lib/Controller/AggregatorController.php
@@ -59,7 +59,7 @@ class AggregatorController extends EntityController {
 		if (isset($identifier)) {	// add entity to aggregator
 			$aggregator = $this->get($identifier);
 
-			if ($uuids = self::makeArray($this->request->query->get('uuid'))) {
+			if ($uuids = self::makeArray($this->getParameters()->get('uuid'))) {
 				foreach ($uuids as $uuid) {
 					$aggregator->addChild(EntityController::factory($this->em, $uuid));
 				}
@@ -69,7 +69,7 @@ class AggregatorController extends EntityController {
 			}
 		}
 		else {	// create new aggregator
-			$type = $this->request->query->get('type');
+			$type = $this->getParameters()->get('type');
 
 			if (!isset($type)) {
 				$type = 'group';
@@ -77,7 +77,7 @@ class AggregatorController extends EntityController {
 
 			$aggregator = new Model\Aggregator($type);
 
-			$this->setProperties($aggregator, $this->request->query->all());
+			$this->setProperties($aggregator, $this->getParameters()->all());
 			$this->em->persist($aggregator);
 		}
 
@@ -94,7 +94,7 @@ class AggregatorController extends EntityController {
 			return;
 
 		$aggregator = NULL;
-		if ($uuids = self::makeArray($this->request->query->get('uuid'))) { // remove entity from aggregator
+		if ($uuids = self::makeArray($this->getParameters()->get('uuid'))) { // remove entity from aggregator
 			$aggregator = $this->get($identifier);
 
 			foreach ($uuids as $uuid) {

--- a/lib/Controller/ChannelController.php
+++ b/lib/Controller/ChannelController.php
@@ -58,14 +58,14 @@ class ChannelController extends EntityController {
 	 * Add channel
 	 */
 	public function add() {
-		$type = $this->request->query->get('type');
+		$type = $this->getParameters()->get('type');
 
 		if (!isset($type)) {
 			throw new \Exception('Missing entity type');
 		}
 
 		$channel = new Model\Channel($type);
-		$this->setProperties($channel, $this->request->query->all());
+		$this->setProperties($channel, $this->getParameters()->all());
 
 		$this->em->persist($channel);
 		$this->em->flush();

--- a/lib/Controller/DataController.php
+++ b/lib/Controller/DataController.php
@@ -46,7 +46,7 @@ class DataController extends Controller {
 	public function __construct(Request $request, EntityManager $em, View $view) {
 		parent::__construct($request, $em, $view);
 
-		$this->options = self::makeArray(strtolower($this->request->query->get('options')));
+		$this->options = self::makeArray(strtolower($this->getParameters()->get('options')));
 	}
 
 	/**
@@ -55,10 +55,10 @@ class DataController extends Controller {
 	 * @param string|array uuid
 	 */
 	public function get($uuid) {
-		$from = $this->request->query->get('from');
-		$to = $this->request->query->get('to');
-		$tuples = $this->request->query->get('tuples');
-		$groupBy = $this->request->query->get('group');
+		$from = $this->getParameters()->get('from');
+		$to = $this->getParameters()->get('to');
+		$tuples = $this->getParameters()->get('tuples');
+		$groupBy = $this->getParameters()->get('group');
 
 		// single UUID
 		if (is_string($uuid)) {
@@ -104,8 +104,8 @@ class DataController extends Controller {
 			}, array());
 		}
 		catch (\RuntimeException $e) { /* fallback to old method */
-			$timestamp = $this->request->query->get('ts');
-			$value = $this->request->query->get('value');
+			$timestamp = $this->getParameters()->get('ts');
+			$value = $this->getParameters()->get('value');
 
 			if (is_null($timestamp)) {
 				$timestamp = (double) round(microtime(TRUE) * 1000);
@@ -141,10 +141,10 @@ class DataController extends Controller {
 		$to = null;
 
 		// parse interval
-		if (null !== ($from = $this->request->query->get('from'))) {
+		if (null !== ($from = $this->getParameters()->get('from'))) {
 			$from = Interpreter::parseDateTimeString($from);
 
-			if (null !== ($to = $this->request->query->get('to'))) {
+			if (null !== ($to = $this->getParameters()->get('to'))) {
 				$to = Interpreter::parseDateTimeString($to);
 
 				if ($from > $to) {
@@ -152,7 +152,7 @@ class DataController extends Controller {
 				}
 			}
 		}
-		elseif ($from = $this->request->query->get('ts')) {
+		elseif ($from = $this->getParameters()->get('ts')) {
 			$to = $from;
 		}
 		else {

--- a/lib/Controller/EntityController.php
+++ b/lib/Controller/EntityController.php
@@ -55,7 +55,7 @@ class EntityController extends Controller {
 		}
 		elseif (is_array($uuids)) { // multiple entities
 			$entities = array();
-			$allowInvalidUuid = $this->request->query->get('nostrict');
+			$allowInvalidUuid = $this->getParameters()->get('nostrict');
 
 			foreach ($uuids as $uuid) {
 				try {
@@ -146,7 +146,7 @@ class EntityController extends Controller {
 			throw new \Exception('Invalid operation - missing entity.');
 		}
 
-		$this->setProperties($entity, $this->request->query->all());
+		$this->setProperties($entity, $this->getParameters()->all());
 		$this->em->flush();
 
 		if (self::$cache) {

--- a/lib/Router.php
+++ b/lib/Router.php
@@ -61,10 +61,11 @@ class Router implements HttpKernelInterface {
 	 * @var array HTTP-method => operation mapping
 	 */
 	public static $operationMapping = array(
-		'post'			=> 'add',
-		'delete'		=> 'delete',
-		'get'			=> 'get',
-		'pull'			=> 'edit'
+		'POST'			=> 'add',
+		'DELETE'		=> 'delete',
+		'GET'			=> 'get',
+		'PATCH'			=> 'edit',
+		'PULL'			=> 'edit'		// not REST-conform
 	);
 
 	/**
@@ -193,7 +194,7 @@ class Router implements HttpKernelInterface {
 	function handler(Request $request, $context, $uuid) {
 		// get controller operation
 		if (null === ($operation = $request->query->get('operation'))) {
-			$operation = self::$operationMapping[strtolower($request->getMethod())];
+			$operation = self::$operationMapping[$request->getMethod()];
 		}
 
 		$class = self::$controllerMapping[$context];


### PR DESCRIPTION
Instead of using the `&operation=xyz` parameter with `GET` requests use native HTTP methods. This makes the frontend conforming to the RESTful paradigm. Also changing `PULL` to `PATCH` for edit methods, again for REST conformance. `PULL` is still supported for backwards compatibility.