### PR TITLE
Fix websocket auto discovery

### DIFF
--- a/htdocs/frontend/javascripts/init.js
+++ b/htdocs/frontend/javascripts/init.js
@@ -143,7 +143,7 @@ $(document).ready(function() {
 						uri += ":" + parser.port;
 					}
 					// if Apache ProxyPass is used, connect with http(s) but always forward to unencrypted port
-					uri += parser.pathname.replace(/middleware.php$/, "ws");
+					uri += "/ws"; // parser.pathname.replace(/(\.\.\/)?middleware.php$/, "ws")
 					console.info("Live updates not configured. Trying default path at " + uri);
 				}
 				else {


### PR DESCRIPTION
Fix IE path error from https://github.com/volkszaehler/volkszaehler.org/issues/461. Without this fix, when local middleware is configured like `../middleware.php`, IE would fail trying to establish websocket connection to `http://localhost../ws` which is not a valid uri.