### PR TITLE
Responsive ui

### DIFF
--- a/htdocs/frontend/index.html
+++ b/htdocs/frontend/index.html
@@ -110,7 +110,7 @@
 						<th><img src="images/blank.png" class="icon-eye" alt="Anzeige" id="entity-toggle" title="Toggle entitites" /></th>
 						<th></th>
 						<th>Titel</th>
-						<th>Typ</th>
+						<th class="type">Typ</th>
 						<th class="min">Min.</th>
 						<th class="max">Max.</th>
 						<th class="average">&empty;</th>

--- a/htdocs/frontend/index.html
+++ b/htdocs/frontend/index.html
@@ -77,7 +77,7 @@
 <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
 <![endif]-->
 <div id="content">
-	<div id="headline">
+	<div id="header">
 		<h2 id="title"></h2>
 
 		<div id="export">

--- a/htdocs/frontend/javascripts/entity.js
+++ b/htdocs/frontend/javascripts/entity.js
@@ -617,7 +617,7 @@ Entity.prototype.getDOMRow = function(parent) {
 				)
 			)
 		)
-		.append($('<td>').text(type)) // channel type
+		.append($('<td>').addClass('type').text(type)) // channel type
 		.append($('<td>').addClass('min'))		// min
 		.append($('<td>').addClass('max'))		// max
 		.append($('<td>').addClass('average'))		// avg

--- a/htdocs/frontend/javascripts/functions.js
+++ b/htdocs/frontend/javascripts/functions.js
@@ -184,6 +184,10 @@ vz.parseUrlParams = function() {
 				case 'options': // data load options
 					vz.options[key] = vars[key];
 					break;
+
+				case 'hide':
+					$(vars[key]).hide();
+					break;
 			}
 		}
 	}

--- a/htdocs/frontend/stylesheets/style.css
+++ b/htdocs/frontend/stylesheets/style.css
@@ -1,7 +1,7 @@
 body {
 	margin: 0;
 	padding: 0;
-	background-color: #0292C0;
+	background-color: white;
 	font-family: sans-serif;
 }
 
@@ -34,7 +34,6 @@ tr.property td, tr.entity td {
 
 #content {
 	padding: 10px;
-	background-color: white;
 }
 
 #content div {
@@ -82,8 +81,9 @@ tr.property td, tr.entity td {
 #footer {
 	text-align: center;
 	font-size: 0.7em;
+	background-color: #0292C0;
 	color: white;
-	margin: 10px;
+	padding: 10px;
 }
 
 #footer a, #footer a:visited {

--- a/htdocs/frontend/stylesheets/style.css
+++ b/htdocs/frontend/stylesheets/style.css
@@ -18,6 +18,10 @@ tr th {
 	font-size: 0.9em;
 }
 
+tr td {
+	font-size: 1em;
+}
+
 tr.optional,
 tr.stale td.min, tr.stale td.max, tr.stale td.average, tr.stale td.last,
 tr.stale td.consumption, tr.stale td.cost, tr.stale td.total {
@@ -177,6 +181,40 @@ select.icons option {
 	width: 100%;
 }
 
+/* mobile styles */
+
+@media only screen and (max-width: 40em) {
+	/* small */
+	table .min, table .max, table .average {
+		display: none;
+	}
+	tr td {
+		font-size: 0.9em;
+	}
+	#footer {
+		display: none;
+	}
+}
+
+/*@media only screen and (min-width: 40.063em) and (max-width: 64em) {*/
+@media only screen and (max-width: 64em) {
+	/* medium */
+	table .type {
+		display: none;
+	}
+	h2 {
+		font-size: 1.2em;
+	}
+	#controls button {
+		font-size: 0.9em;
+	}
+	.ui-widget {
+		font-size: 1em;
+	}
+	.ui-widget .ui-widget {
+		font-size: 0.9em;
+	}
+}
 
 /* jQuery UI customizations */
 input.ui-button {


### PR DESCRIPTION
Fix https://github.com/volkszaehler/volkszaehler.org/issues/495 and add some responsive UI elements for smaller screen sizes.

To hide UI elements add their CSS selectors:

```
?hide=#footer,#header,#accordion
```

To get rid of the options section only:

```
?hide=h3:not(:first-of-type)
```

To add UUIDS:

```
&uuid[]=abc&uuid[]=def
```
