### PR TITLE
Add maxPrecison number format

### DIFF
--- a/htdocs/frontend/javascripts/options.js
+++ b/htdocs/frontend/javascripts/options.js
@@ -27,6 +27,9 @@
 vz.options = {
 	language: 'de',
 	precision: 2,							// TODO update from middleware capabilities?
+	maxPrecision: {						// override precision for certain units
+		'°C': 1
+	},
 	tuples: null,							// automatically determined by plot size
 	refresh: true,						// update chart if zoomed to current timestamp
 	interval: 24*60*60*1000,	// 1 day default time interval to show
@@ -48,7 +51,7 @@ vz.options = {
 			url: '//demo.volkszaehler.org/middleware.php'
 		}
 	],
-	monthNames: ['Jan', 'Feb', unescape('M%E4r'), 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez'],
+	monthNames: ['Jan', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez'],
 	dayNames: ['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa'],
 	lineWidthDefault: 2,
 	lineWidthSelected: 4,

--- a/htdocs/frontend/javascripts/wui.js
+++ b/htdocs/frontend/javascripts/wui.js
@@ -733,6 +733,10 @@ vz.wui.formatNumber = function(number, unit, prefix) {
 	// avoid infinities/NaN
 	if (number < 0 || number > 0) {
 		var precision = Math.max(0, vz.options.precision - Math.floor(Math.log(Math.abs(number))/Math.LN10));
+		// apply maximum precision e.g. for °C values
+		if (vz.options.maxPrecision[unit] !== undefined) {
+			precision = Math.min(vz.options.maxPrecision[unit], precision);
+		}
 		number = Math.round(number * Math.pow(10, precision)) / Math.pow(10, precision); // rounding
 	}
 


### PR DESCRIPTION
Allow to e.g. make sure temperature is never display with more then 1 digit precision.