### PR TITLE
Prevent duplicate push subscription

### DIFF
--- a/htdocs/frontend/javascripts/entity.js
+++ b/htdocs/frontend/javascripts/entity.js
@@ -280,6 +280,8 @@ Entity.prototype.loadDetails = function(skipDefaultErrorHandling) {
 		identifier: this.uuid,
 		context: this
 	}, skipDefaultErrorHandling).done(function(json) {
+		// fix https://github.com/volkszaehler/volkszaehler.org/pull/560
+		delete json.active;
 		this.parseJSON(json.entity);
 	});
 };
@@ -386,11 +388,15 @@ Entity.prototype.showDetails = function() {
 				$('#entity-edit form table .optional').remove();
 
 				// add properties for entity
-				vz.capabilities.definitions.entities.some(function(entities) {
-					if (entities.name == entity.type) {
-						var container = $('#entity-edit form table');
-						vz.wui.dialogs.addProperties(container, entities.required, "required", entity);
-						vz.wui.dialogs.addProperties(container, entities.optional, "optional", entity);
+				vz.capabilities.definitions.entities.some(function(definition) {
+					if (definition.name == entity.type) {
+						// fix https://github.com/volkszaehler/volkszaehler.org/pull/560
+						if (definition.optional.indexOf('active') >= 0) {
+							definition.optional.splice(definition.optional.indexOf('active'), 1);
+						}
+						var container = $('#entity-edit table');
+						vz.wui.dialogs.addProperties(container, definition.required, "required", entity);
+						vz.wui.dialogs.addProperties(container, definition.optional, "optional", entity);
 						return true;
 					}
 				});

--- a/htdocs/frontend/javascripts/middleware.js
+++ b/htdocs/frontend/javascripts/middleware.js
@@ -47,8 +47,9 @@ Middleware.prototype.loadEntities = function() {
 		this.public = [];
 
 		json.entities.forEach(function(json) {
-			var entity = new Entity(json, this.url);
-			this.public.push(entity);
+			// fix https://github.com/volkszaehler/volkszaehler.org/pull/560
+			json.active = false;
+			this.public.push(new Entity(json, this.url));
 		}, this);
 		this.public.sort(Entity.compare);
 


### PR DESCRIPTION
Fix mailing list issue of Andre:

> In Entity.prototype.updateDOMRow wird die Tabellenzeile zunächst geleert, um sie dann mit neuen Daten zu befüllen. In meinem Fall hat das übergeben JS Objekt keinen Member "rows" [if (this.data && this.data.rows > 0)]. Die Tabelle wird bei mir korrekt geleert, aber es werden keine neuen Daten geparsed. Unabhängig von der Ursache könnte das clear mit ins if, damit umgeht man den Fehler aber natürlich nur.

> Ich denke es werden zwei Subscriptions pro Channel erzeugt. Eine davon hat kein passendes data Objekt als Member (hat eher die Struktur mit min, max und tuples). Kann es daran liegen, dass neuerdings "active" als Channel-Property in die DB geschrieben wird? parseJSON erzeugt bei mir beim Laden Subscriptions auch für nicht angezeigte - aber aktive Channels. Zusätzlich werden in init.js nach dem WAMP connect noch die "richtigen" Subscriptions erzeugt, wenn der Channel aktiv und sichtbar ist. Vom Timing her hab ich die korrupte Subscription immer als zweites, ich bekomme also ein korrektes Update und dann sofort das leere. Setze ich in der db active=0 funktioniert es übrigens.