### PR TITLE
don't highlight inactive channels

### DIFF
--- a/htdocs/frontend/javascripts/entities.js
+++ b/htdocs/frontend/javascripts/entities.js
@@ -285,14 +285,14 @@ vz.entities.showTable = function() {
 	// make visible that a row is clicked
 	$('#entity-list table tbody tr').mousedown(function() {
 		var entity = $(this).data('entity');
-		var selected = $('tr.selected').data('entity');
+		var selected = $('tr.selected');
 
-		$('tr.selected').removeClass('selected'); // deselect currently selected rows
+		selected.removeClass('selected'); // deselect currently selected rows
 		vz.wui.selectedChannel = null;
 
-		if (entity !== selected) {
+		if (entity !== selected.data('entity') && entity.active) {
 			$(this).addClass('selected');
-			vz.wui.selectedChannel = entity.index;
+			vz.wui.selectedChannel = entity.uuid;
 		}
 		vz.wui.drawPlot();
 	});

--- a/htdocs/frontend/javascripts/wui.js
+++ b/htdocs/frontend/javascripts/wui.js
@@ -829,7 +829,7 @@ vz.wui.drawPlot = function () {
 		vz.options.plot.axesAssigned = true;
 	}
 
-	var series = [], index = 0;
+	var series = [];
 	vz.entities.each(function(entity) {
 		if (entity.active && entity.definition && entity.definition.model == 'Volkszaehler\\Model\\Channel' &&
 				entity.data && entity.data.tuples && entity.data.tuples.length > 0) {
@@ -843,7 +843,7 @@ vz.wui.drawPlot = function () {
 
 			var style = vz.options.style || entity.style;
 			var fillstyle = parseFloat(vz.options.fillstyle || entity.fillstyle);
-			var linewidth = parseFloat(vz.options.linewidth || vz.options[index == vz.wui.selectedChannel ? 'lineWidthSelected' : 'lineWidthDefault']);
+			var linewidth = parseFloat(vz.options.linewidth || vz.options[entity.uuid == vz.wui.selectedChannel ? 'lineWidthSelected' : 'lineWidthDefault']);
 
 			// mangle data for "steps" curves by shifting one ts left ("step-before")
 			if (style == "steps") {
@@ -885,9 +885,6 @@ vz.wui.drawPlot = function () {
 				serie.xGapThresh = Math.max(entity.gap * 1000 * maxTuples, minGapWidth);
 				vz.options.plot.xaxis.insertGaps = true;
 			}
-
-			// use this index for setting vz.wui.selectedChannel
-			entity.index = index++;
 
 			series.push(serie);
 		}


### PR DESCRIPTION
first, it makes no sense (which is my personal opinion and therefore
debatable). more important, this fixes an itch I always head: due to bad
row indexing, the next active channel's graph got highlighted, which is
definitely wrong.
A minor issue stays: When deactiving a channel (by clicking its checbox)
the row get's highlighted. I will fix this in the next PR by changing
the highlight sensitive area so that the checkbox and the delete/info
actions will not trigger it.
IMO groups should also not be highlightable (as they are not represented in the chart), but again, that's debatable, so I did not change that for now. 

minor refactoring:
- entity.index is not used anywhere else, so I dropped it
- instead of running $('tr.selected') twice, I save the result
