### PR TITLE
Add data button to entity info

### DIFF
--- a/htdocs/js/entity.js
+++ b/htdocs/js/entity.js
@@ -202,7 +202,7 @@ Entity.prototype.subscribe = function(session) {
 
 		// don't collect data if not subscribed
 		if (!this.active || this.data === undefined) {
-		  return;
+			return;
 		}
 
 		var delta = push.data;
@@ -351,6 +351,13 @@ Entity.prototype.showDetails = function() {
 		width: 480,
 		resizable: false,
 		buttons : {
+			'Daten': function() {
+				var params = $.extend($.getUrlParams(), {
+					from: Math.floor(vz.options.plot.xaxis.min),
+					to: Math.ceil(vz.options.plot.xaxis.max)
+				});
+				window.open(entity.middleware + '/data/' + entity.uuid + '.json?' + $.param(params), '_blank');
+			},
 			'Löschen' : function() {
 				$('#entity-delete').dialog({ // confirm prompt
 					resizable: false,
@@ -446,6 +453,9 @@ Entity.prototype.showDetails = function() {
 			'Schließen': function() {
 				$(this).dialog('close');
 			}
+		},
+		open: function() {
+			$(this).siblings('.ui-dialog-buttonpane').find('button:eq(0)').focus();
 		}
 	});
 };


### PR DESCRIPTION
Simplistic approach to https://github.com/volkszaehler/volkszaehler.org/issues/572. Adds a "Data" button to the channel info dialog which opens the current middleware data selection in new view.

Also fixed the default selection behavior when opening the info dialog multiple times.

ping @frankrichter