### PR TITLE
Disable demo middleware by default

### DIFF
--- a/htdocs/js/options.js
+++ b/htdocs/js/options.js
@@ -46,9 +46,9 @@ vz.options = {
 														//    - either apache proxy forwarding configured according to
 														//			https://github.com/volkszaehler/volkszaehler.org/issues/382
 														// 		- or push-server live update port configured and accessible
-		}, {
-			title: 'Volkszaehler Demo',
-			url: 'https://demo.volkszaehler.org/middleware.php'
+		// }, {
+			// title: 'Volkszaehler Demo',
+			// url: 'https://demo.volkszaehler.org/middleware.php'
 		}
 	],
 	monthNames: ['Jan', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez'],


### PR DESCRIPTION
to avoid unnecessary connections to demo push-server