### PR TITLE
Fix invalid partial entities when retrieving by name

### DIFF
--- a/lib/Controller/DataController.php
+++ b/lib/Controller/DataController.php
@@ -60,9 +60,10 @@ class DataController extends Controller {
 		$dql = 'SELECT e, p
 			FROM Volkszaehler\Model\Entity e
 			LEFT JOIN e.properties p
+			LEFT JOIN e.properties title
 			JOIN e.properties public
-			WHERE p.key = :key
-			AND p.value = :name
+			WHERE title.key = :key
+			AND title.value = :name
 			AND public.key = :key2
 			AND public.value = 1';
 
@@ -93,14 +94,15 @@ class DataController extends Controller {
 				// allow retrieving entity by name
 				try {
 					$entity = $this->getSingleEntityByName($uuid);
-					$uuid = $entity->getUuid();
 				}
 				catch (ORMException $e) {
 					throw new \Exception('Channel \'' . $uuid . '\' does not exist, is not public or its name is not unique.');
 				}
 			}
+			else {
+				$entity = EntityController::factory($this->em, $uuid, true); // from cache
+			}
 
-			$entity = EntityController::factory($this->em, $uuid, true); // from cache
 			$class = $entity->getDefinition()->getInterpreter();
 			return new $class($entity, $this->em, $from, $to, $tuples, $groupBy, $this->options);
 		}

--- a/lib/Controller/EntityController.php
+++ b/lib/Controller/EntityController.php
@@ -125,7 +125,7 @@ class EntityController extends Controller {
 			$entity = $q->getSingleResult();
 
 			if ($allowCache && self::$cache) {
-				self::$cache->save($uuid, $entity, Util\Configuration::read('cache.ttl'));
+				self::$cache->save($uuid, $entity, Util\Configuration::read('cache.ttl', 3600));
 			}
 
 			return $entity;


### PR DESCRIPTION
Fixes a problem when using public name notation like `middleware/data/bezug.json`