### PR TITLE
Refactor entity generation

### DIFF
--- a/htdocs/js/entities.js
+++ b/htdocs/js/entities.js
@@ -78,7 +78,7 @@ vz.entities.loadDetails = function() {
 			function(xhr) {
 				var exception = (xhr.responseJSON || {}).exception;
 				// default error handling is skipped - be careful
-				if (exception && exception.message.match(/^Invalid UUID|^No entity found with UUID/)) {
+				if (exception && exception.message.match(/^Invalid UUID|^No entity/)) {
 					vz.entities.splice(vz.entities.indexOf(entity), 1); // remove
 					return $.Deferred().resolveWith(this, [xhr.responseJSON]);
 				}

--- a/lib/Controller/ChannelController.php
+++ b/lib/Controller/ChannelController.php
@@ -34,24 +34,28 @@ use Volkszaehler\Model;
 class ChannelController extends EntityController {
 
 	/**
-	 * Get channel
-	 * @param null $identifier
+	 * Get one or more channels.
+	 * If uuid is empty, list of public channels is returned.
+	 *
+	 * @param $identifier
 	 * @return array
 	 * @throws \Exception
 	 */
-	public function get($identifier = NULL) {
-		$channel = parent::get($identifier);
+	public function get($uuid = NULL) {
+		$channel = parent::get($uuid);
 
-		if (is_array($channel)) { // filter public entities
-			return array('channels' => array_values(array_filter($channel['entities'], function($ch) {
-				return ($ch instanceof Model\Channel);
-			})));
+		if (is_array($channel)) { // filter channels
+			return array('channels' => array_values(
+				array_filter($channel['entities'], function($ch) {
+					return ($ch instanceof Model\Channel);
+				})
+			));
 		}
 		else if ($channel instanceof Model\Channel) {
 			return $channel;
 		}
 		else {
-			throw new \Exception('Entity is not a channel: \'' . $identifier . '\'');
+			throw new \Exception('Entity is not a channel: \'' . $uuid . '\'');
 		}
 	}
 

--- a/lib/Controller/Controller.php
+++ b/lib/Controller/Controller.php
@@ -26,6 +26,8 @@ namespace Volkszaehler\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Doctrine\ORM\EntityManager;
+
+use Volkszaehler\Util\EntityFactory;
 use Volkszaehler\View\View;
 
 /**
@@ -58,6 +60,11 @@ abstract class Controller {
 	protected $view;
 
 	/**
+	 * @var EntityFactory
+	 */
+	protected $ef;
+
+	/**
 	 * Constructor
 	 *
 	 * @param Request $request
@@ -68,6 +75,7 @@ abstract class Controller {
 		$this->request = $request;
 		$this->em = $em;
 		$this->view = $view;
+		$this->ef = EntityFactory::getInstance($em);
 	}
 
 	/**
@@ -92,7 +100,7 @@ abstract class Controller {
 	 * @return operation result
 	 * @throws \Exception
 	 */
-	public function run($op, $uuid = null) {
+	public function run($op, $uuid) {
 		if (!method_exists($this, $op)) {
 			throw new \Exception('Invalid context operation: \'' . $op . '\'');
 		}

--- a/lib/Controller/EntityController.php
+++ b/lib/Controller/EntityController.php
@@ -39,110 +39,47 @@ use Volkszaehler\Definition;
 class EntityController extends Controller {
 
 	/**
-	 * Memory cache instance, e.g. APC
-	 */
-	protected static $cache;
-
-	/**
-	 * Get entity
+	 * Get one or more entities.
+	 * If uuid is empty, list of public entities is returned.
 	 *
-	 * @param $uuids
+	 * @param $uuid
 	 * @return array
 	 * @throws \Exception
 	 */
-	public function get($uuids) {
-		if (is_string($uuids)) { // single entity
-			return $this->getSingleEntity($uuids);
+	public function get($uuid) {
+		if (is_string($uuid)) { // single entity
+			return $this->ef->get($uuid, true);
 		}
-		elseif (is_array($uuids)) { // multiple entities
-			$entities = array();
-			$allowInvalidUuid = $this->getParameters()->get('nostrict');
 
-			foreach ($uuids as $uuid) {
+		if (is_array($uuid)) { // multiple entities
+			$entities = array();
+			$strict = !$this->getParameters()->get('nostrict');
+
+			foreach ($uuid as $_uuid) {
 				try {
-					$entities[] = $this->getSingleEntity($uuid);
+					$entities[] = $this->ef->get($_uuid, true);
 				}
 				catch (\Exception $e) {
-					if ($allowInvalidUuid) {
-						// return empty entity
-						$entities[] = array('uuid' => $uuid);
-					}
-					else {
+					if ($strict) {
 						throw $e;
 					}
 				}
 			}
-
-			return array('entities' => $entities);
 		}
 		else { // public entities
-			return array('entities' => $this->filter(array('public' => TRUE)));
-		}
-	}
-
-	/**
-	 * Return a single entity, potentially from cache
-	 * @param $uuid
-	 * @param bool $allowCache
-	 * @return mixed
-	 */
-	public function getSingleEntity($uuid, $allowCache = false) {
-		return self::factory($this->em, $uuid, $allowCache);
-	}
-
-	/**
-	 * Static entity factory- usable for scripting
-	 *
-	 * @param EntityManager $em
-	 * @param $uuid
-	 * @param bool $allowCache
-	 * @return mixed
-	 * @throws \Exception
-	 */
-	static function factory(EntityManager $em, $uuid, $allowCache = false) {
-		if (!Util\UUID::validate($uuid)) {
-			throw new \Exception('Invalid UUID: \'' . $uuid . '\'');
+			$entities = $this->ef->getByProperties(array('public' => true));
 		}
 
-		if (!self::$cache) {
-			self::$cache = $em->getConfiguration()->getQueryCacheImpl();
-		}
-
-		if ($allowCache && self::$cache && self::$cache->contains($uuid)) {
-			// used hydrated cache result
-			return self::$cache->fetch($uuid);
-		}
-
-		$dql = 'SELECT a, p
-			FROM Volkszaehler\Model\Entity a
-			LEFT JOIN a.properties p
-			WHERE a.uuid = :uuid';
-
-		$q = $em->createQuery($dql)
-			->setParameter('uuid', $uuid);
-
-		try {
-			$entity = $q->getSingleResult();
-
-			if ($allowCache && self::$cache) {
-				self::$cache->save($uuid, $entity, Util\Configuration::read('cache.ttl', 3600));
-			}
-
-			return $entity;
-		} catch (\Doctrine\ORM\NoResultException $e) {
-			throw new \Exception('No entity found with UUID: \'' . $uuid . '\'');
-		}
+		return array('entities' => $entities);
 	}
 
 	/**
 	 * Delete entity by uuid
-	 * @param $identifier
+	 * @param $uuid
 	 * @throws \Exception
 	 */
-	public function delete($identifier) {
-		if (!($entity = $this->get($identifier)) instanceof Model\Entity) {
-			throw new \Exception('Invalid operation - missing entity.');
-		}
+	public function delete($uuid) {
+		$entity = $this->ef->get($uuid);
 
 		if ($entity instanceof Model\Channel) {
 			$entity->clearData($this->em->getConnection());
@@ -150,29 +87,21 @@ class EntityController extends Controller {
 
 		$this->em->remove($entity);
 		$this->em->flush();
-
-		if (self::$cache) {
-			self::$cache->delete($identifier);
-		}
+		$this->ef->remove($uuid);
 	}
 
 	/**
 	 * Edit entity properties
-	 * @param $identifier
+	 * @param $uuid
 	 * @return array
 	 * @throws \Exception
 	 */
-	public function edit($identifier) {
-		if (!($entity = $this->get($identifier)) instanceof Model\Entity) {
-			throw new \Exception('Invalid operation - missing entity.');
-		}
+	public function edit($uuid) {
+		$entity = $this->ef->get($uuid);
 
 		$this->setProperties($entity, $this->getParameters()->all());
 		$this->em->flush();
-
-		if (self::$cache) {
-			self::$cache->delete($identifier);
-		}
+		$this->ef->remove($uuid);
 
 		// HACK - see https://github.com/doctrine/doctrine2/pull/382
 		$entity->castProperties();
@@ -204,40 +133,6 @@ class EntityController extends Controller {
 		}
 
 		$entity->checkProperties();
-	}
-
-	/**
-	 * Filter entities by properties
-	 *
-	 * @param array of property => value filters
-	 * @return array of entities
-	 */
-	public function filter(array $properties) {
-		$dql = 'SELECT e, p
-			FROM Volkszaehler\Model\Entity e
-			LEFT JOIN e.properties p';
-
-		$i = 0;
-		$sqlWhere = array();
-		$sqlParams = array();
-		foreach ($properties as $key => $value) {
-			if (Definition\PropertyDefinition::get($key)->getType() == 'boolean') {
-				$value = (int) $value;
-			}
-			$sqlWhere[] = 'EXISTS (SELECT p' . $i . ' FROM \Volkszaehler\Model\Property p' . $i . ' WHERE p' . $i . '.key = :key' . $i . ' AND p' . $i . '.value = :value' . $i . ' AND p' . $i . '.entity = e)';
-			$sqlParams += array(
-				'key' . $i => $key,
-				'value' . $i => $value
-			);
-			$i++;
-		}
-
-		if (count($sqlWhere) > 0) {
-			$dql .= ' WHERE ' . implode(' AND ', $sqlWhere);
-		}
-
-		$q = $this->em->createQuery($dql);
-		return $q->execute($sqlParams);
 	}
 }
 

--- a/lib/Controller/IotController.php
+++ b/lib/Controller/IotController.php
@@ -36,36 +36,19 @@ use Volkszaehler\View\View;
 class IotController extends Controller {
 
 	/**
-	 * @var Volkszaehler\Controller\EntityController
-	 */
-	protected $ec;
-
-	/**
-	 * IotController constructor
-	 *
-	 * @param Request $request
-	 * @param EntityManager $em
-	 * @param View $view
-	 */
-	public function __construct(Request $request, EntityManager $em, View $view) {
-		parent::__construct($request, $em, $view);
-		$this->ec = new EntityController($request, $em);
-	}
-
-	/**
 	 * Run operation
 	 *
 	 * @param null $uuid
 	 * @return array
 	 * @throws \Exception
 	 */
-	public function get($uuid = null) {
-		if ($uuid === null || is_array($uuid) || strlen($uuid) < 32) {
+	public function get($secret) {
+		if ($secret === null || is_array($secret) || strlen($secret) < 32) {
 			throw new \Exception('Invalid identifier');
 		}
 
-		// treat uuid as identifier stored in (hidden) owner parameter
-		return array('entities' => $this->ec->filter(array('owner' => $uuid)));
+		// treat secret as identifier stored in (hidden) owner parameter
+		return array('entities' => $this->ef->getByProperties(array('owner' => $secret)));
 	}
 }
 

--- a/lib/Router.php
+++ b/lib/Router.php
@@ -233,13 +233,13 @@ class Router implements HttpKernelInterface {
 	 * @param bool $admin
 	 * @return ORM\EntityManager
 	 */
-	public static function createEntityManager($admin = FALSE) {
+	public static function createEntityManager($admin = false) {
 		$config = new ORM\Configuration;
 
-		if (Util\Configuration::read('devmode') == FALSE) {
+		if (Util\Configuration::read('devmode') == false) {
 			$cache = null;
 			if (extension_loaded('apcu'))
-				$cache = new Cache\ApcuCache;
+				$cache = new Cache\ApcuCache();
 			if ($cache) {
 				$config->setMetadataCacheImpl($cache);
 				$config->setQueryCacheImpl($cache);
@@ -261,6 +261,9 @@ class Router implements HttpKernelInterface {
 		if ($admin && isset($dbConfig['admin'])) {
 			$dbConfig = array_merge($dbConfig, $dbConfig['admin']);
 		}
+
+		// reset singleton to use new entity manager
+		Util\EntityFactory::reset();
 
 		return ORM\EntityManager::create($dbConfig, $config);
 	}

--- a/lib/Server/MiddlewareAdapter.php
+++ b/lib/Server/MiddlewareAdapter.php
@@ -26,7 +26,7 @@ namespace Volkszaehler\Server;
 
 use Volkszaehler\Router;
 use Volkszaehler\Interpreter;
-use Volkszaehler\Controller\EntityController;
+use Volkszaehler\Util\EntityFactory;
 
 use Symfony\Component\HttpFoundation\Request;
 
@@ -72,7 +72,7 @@ class MiddlewareAdapter {
 		try {
 			$this->openController();
 
-			$entity = EntityController::factory($this->em, $uuid);
+			$entity = EntityFactory::getInstance($this->em)->getByUuid($uuid);
 			$class = $entity->getDefinition()->getInterpreter();
 			$interpreter = new $class($entity, $this->em, null, null);
 

--- a/lib/Util/EntityFactory.php
+++ b/lib/Util/EntityFactory.php
@@ -1,0 +1,240 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017, The volkszaehler.org project
+ * @package default
+ * @license http://www.opensource.org/licenses/gpl-license.php GNU Public License
+ */
+/*
+ * This file is part of volkzaehler.org
+ *
+ * volkzaehler.org is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * volkzaehler.org is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with volkszaehler.org. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Volkszaehler\Util;
+
+use Doctrine\ORM;
+use Doctrine\Common\Cache;
+
+use Volkszaehler\Util;
+use Volkszaehler\Definition\PropertyDefinition;
+
+/**
+ * Entity factory
+ *
+ * @author Andreas Götz <cpuidle@gmx.de>
+ * @package default
+ */
+class EntityFactory {
+
+	/**
+	 * Factory instance
+	 */
+	protected static $instance;
+
+	/**
+	 * @var Doctrine\ORM\EntityManager
+	 */
+	protected $em;
+
+	/**
+	 * Memory cache instance, e.g. APC
+	 */
+	protected $cache;
+
+	/**
+	 * Cache ttl
+	 */
+	protected $ttl;
+
+	/**
+	 * Create singleton instance
+	 */
+	public static function getInstance(ORM\EntityManager $em) {
+		if (!isset(self::$instance)) {
+			self::$instance = new EntityFactory($em);
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Reset singleton instance
+	 */
+	public static function reset() {
+		self::$instance = null;
+	}
+
+	/**
+	 * Instance
+	 */
+	protected function __construct(ORM\EntityManager $em) {
+		$this->em = $em;
+		$this->cache = $em->getConfiguration()->getQueryCacheImpl();
+
+		if (!isset($this->cache)) {
+			$this->cache = new Cache\ArrayCache();
+		}
+	}
+
+	/**
+	 * Return a single entity by identifier, either UUID or name
+	 * @param $uuid
+	 * @param bool $cache Use cache
+	 * @throws Exception on empty result
+	 * @return Entity
+	 */
+	public function get($uuid, $cache = false) {
+		if (empty($uuid)) {
+			throw new \Exception('Missing UUID');
+		}
+		if (UUID::validate($uuid)) {
+			return $this->getByUuidUnvalidated($uuid, $cache);
+		}
+		return $this->getByName($uuid, $cache);
+	}
+
+	/**
+	 * Return a single entity by UUID, potentially from cache
+	 *
+	 * @param $uuid
+	 * @param bool $cache Use cache
+	 * @throws Exception on empty result
+	 * @return Entity
+	 */
+	public function getByUuid($uuid, $cache = false) {
+		if (!UUID::validate($uuid)) {
+			throw new \Exception('Invalid UUID: \'' . $uuid . '\'');
+		}
+		return $this->getByUuidUnvalidated($uuid, $cache);
+	}
+
+	/**
+	 * Return a single entity by UUID, potentially from cache.
+	 * Does not validate UUID.
+	 *
+	 * @param $uuid
+	 * @param bool $cache Use cache
+	 * @throws Exception on empty result
+	 * @return Entity
+	 */
+	protected function getByUuidUnvalidated($uuid, $cache = false) {
+		return $this->cached($uuid, $cache, function() use ($uuid) {
+			$dql = 'SELECT e, p
+				FROM Volkszaehler\Model\Entity e
+				LEFT JOIN e.properties p
+				WHERE e.uuid = :uuid';
+
+			$q = $this->em->createQuery($dql)->setParameter('uuid', $uuid);
+
+			try {
+				$entity = $q->getSingleResult();
+				return $entity;
+			}
+			catch (ORM\NoResultException $e) {
+				throw new \Exception('No entity with UUID \'' . $uuid . '\'');
+			}
+		});
+	}
+
+	/**
+	 * Return a single public entity by name, potentially from cache
+	 *
+	 * @param $name
+	 * @param bool $cache Use cache
+	 * @throws Exception on empty or multiple results
+	 * @return Entity
+	 */
+	public function getByName($name, $cache = false) {
+		return $this->cached($name, $cache, function() use ($name) {
+			$entities = $this->getByProperties(array(
+				'title' => $name,
+				'public' => 1
+			));
+
+			if (count($entities) != 1) {
+				throw new \Exception('Invalid UUID ' . $name);
+			}
+
+			return array_shift($entities);
+		});
+	}
+
+	/**
+	 * Return multiple entities by properties
+	 *
+	 * @param array of property => value filters
+	 * @return array of entities
+	 */
+	public function getByProperties(array $properties) {
+		$dql = 'SELECT e, p
+			FROM Volkszaehler\Model\Entity e
+			LEFT JOIN e.properties p';
+
+		$i = 0;
+		$where = array();
+		$params = array();
+		foreach ($properties as $key => $value) {
+			if (PropertyDefinition::get($key)->getType() == 'boolean') {
+				$value = (int) $value;
+			}
+
+			$dql .= ' JOIN e.properties ' . $key;
+			$where[] = $key.'.key = :key'.$i .' AND '. $key.'.value = :value'.$i;
+			$params += array('key'.$i => $key, 'value'.$i => $value);
+
+			$i++;
+		}
+
+		if (count($where) > 0) {
+			$dql .= ' WHERE ' . implode(' AND ', $where);
+		}
+
+		$q = $this->em->createQuery($dql);
+		return $q->execute($params);
+	}
+
+	/**
+	 * Remove an entity by key from cache
+	 *
+	 * @param $key
+	 */
+	public function remove($key) {
+		if (isset($key)) {
+			$this->cache->delete($key);
+		}
+	}
+
+	/**
+	 * Wrap an EntityManager operation with cache read/write
+	 *
+	 * @throws Exception
+	 */
+	protected function cached($key, $cache, $callable) {
+		if ($cache && $this->cache->contains($key)) {
+			return $this->cache->fetch($key);
+		}
+
+		$entity = $callable();
+
+		if (isset($entity) && $cache) {
+			if (!isset($this->ttl)) {
+				$this->ttl = Util\Configuration::read('cache.ttl', 3600);
+			}
+			$this->cache->save($key, $entity, $this->ttl);
+		}
+
+		return $entity;
+	}
+}
+
+?>

--- a/test/GroupTest.php
+++ b/test/GroupTest.php
@@ -99,6 +99,16 @@ class GroupTest extends Middleware
 	/**
 	 * @depends testCreateGroup
 	 */
+	function testGetGroupAsChannel() {
+		// $this->getTuples($this->ts1-1, $this->ts2);
+		$this->json = $this->getJson('/channel/' . self::$uuid . '.json', array(), 'GET', true);
+
+		$this->assertStringStartsWith('Entity is not a channel', $this->json->exception->message);
+	}
+
+	/**
+	 * @depends testCreateGroup
+	 */
 	function testDeleteGroup() {
 		// delete group
 		$this->getJson('/group/' . self::$uuid . '.json', array(

--- a/test/IotTest.php
+++ b/test/IotTest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * IoT tests
+ *
+ * @package Test
+ * @author Andreas Götz <cpuidle@gmx.de>
+ */
+
+namespace Tests;
+
+use Volkszaehler\Util;
+
+class IotTest extends Middleware
+{
+	protected $uuid;
+
+	function testRetrievel() {
+		$secret = str_replace('-', '', Util\UUID::mint());
+		$this->getJson('/channel.json', array(
+			'operation' => 'add',
+			'title' => 'Power',
+			'type' => 'power',
+			'resolution' => 1,
+			'owner' => $secret
+		), 'GET');
+		$this->assertTrue(isset($this->json->entity), "Expected <entity> got none");
+		$this->assertTrue(isset($this->json->entity->uuid));
+
+		$uuid = $this->json->entity->uuid;
+
+		// retrieve by secret
+		$this->getJson('/iot/' . $secret . '.json');
+		$this->assertTrue(isset($this->json->entities), "Expected <entities> got none");
+		$this->assertEquals(1, count($this->json->entities));
+		$this->assertEquals($uuid, $this->json->entities[0]->uuid);
+	}
+}
+
+?>


### PR DESCRIPTION
This PR is a bigger rewrite of the various methods for creating entities. The current code had become quite complex with creation of entities split across various places and coupled with the request context. That made it hard to use from custom scripts.

With this PR all entity generation is moved into an `EntityFactory`. The use of entity name instead of UUID (in case of a single, public entity of that name) is now possible throughout the API. 

Additional tests have been added to verify exception error messages for empty uuids/ non-existing uuids/ non-existing public entity names.