### PR TITLE
Update vzcompress2.php

### DIFF
--- a/misc/tools/vzcompress2.php
+++ b/misc/tools/vzcompress2.php
@@ -182,7 +182,7 @@ class VZcompress2 {
 
 	private function skipChannel($channel) {
 		if (isset($this->config['channels']) && count($this->config['channels'])) {
-			if (in_array($channel['uuid'], $this->config['channels'])) return true;
+			if (!in_array($channel['uuid'], $this->config['channels'])) return true;
 		}
 		return false;
 	}


### PR DESCRIPTION
skipChannel should return true (-->skip) if channels are defined in the config array and current processed channel is NOT in the array