### PR TITLE
Safari 11 caching issue and other fixes

### DIFF
--- a/htdocs/js/entities.js
+++ b/htdocs/js/entities.js
@@ -77,9 +77,10 @@ vz.entities.loadDetails = function() {
 			},
 			function(xhr) {
 				var exception = (xhr.responseJSON || {}).exception;
+				// remove problematic entity
+				vz.entities.splice(vz.entities.indexOf(entity), 1); // remove
 				// default error handling is skipped - be careful
 				if (exception && exception.message.match(/^Invalid UUID|^No entity/)) {
-					vz.entities.splice(vz.entities.indexOf(entity), 1); // remove
 					// return new resolved deferred
 					return $.Deferred().resolveWith(this, [xhr]);
 				}

--- a/htdocs/js/entities.js
+++ b/htdocs/js/entities.js
@@ -80,14 +80,15 @@ vz.entities.loadDetails = function() {
 				// default error handling is skipped - be careful
 				if (exception && exception.message.match(/^Invalid UUID|^No entity/)) {
 					vz.entities.splice(vz.entities.indexOf(entity), 1); // remove
-					return $.Deferred().resolveWith(this, [xhr.responseJSON]);
+					// return new resolved deferred
+					return $.Deferred().resolveWith(this, [xhr]);
 				}
 				vz.wui.dialogs.middlewareException(xhr);
 				return vz.load.errorHandler(xhr);
 			}
 		));
 	}, true); // recursive
-	return $.when.apply($, queue);
+	return $.whenAll.apply($, queue);
 };
 
 /**

--- a/htdocs/js/functions.js
+++ b/htdocs/js/functions.js
@@ -299,4 +299,59 @@ vz.capabilities.definitions.get = function(section, name) {
 		);
 	};
 
+  var slice = [].slice;
+
+  // https://gist.github.com/fearphage/4341799
+  $.whenAll = function(array) {
+    var
+			/* jshint laxbreak: true */
+      resolveValues = arguments.length == 1 && $.isArray(array)
+        ? array
+        : slice.call(arguments),
+      length = resolveValues.length,
+      remaining = length,
+      deferred = $.Deferred(),
+      i = 0,
+      failed = 0,
+      rejectContexts = Array(length),
+      rejectValues = Array(length),
+      resolveContexts = Array(length),
+      value
+    ;
+
+    function updateFunc (index, contexts, values) {
+      return function() {
+        if (values !== resolveValues) {
+          failed++;
+        }
+        deferred.notifyWith(
+         contexts[index] = this,
+         values[index] = slice.call(arguments)
+        );
+        if (!(--remaining)) {
+          deferred[(!failed ? 'resolve' : 'reject') + 'With'](contexts, values);
+        }
+      };
+    }
+
+    for (; i < length; i++) {
+      if ((value = resolveValues[i]) && $.isFunction(value.promise)) {
+        value.promise()
+          .done(updateFunc(i, resolveContexts, resolveValues))
+          .fail(updateFunc(i, rejectContexts, rejectValues))
+        ;
+      }
+      else {
+        deferred.notifyWith(this, value);
+        --remaining;
+      }
+    }
+
+    if (!remaining) {
+      deferred.resolveWith(resolveContexts, resolveValues);
+    }
+
+    return deferred.promise();
+  };
+
 })(jQuery);

--- a/htdocs/js/functions.js
+++ b/htdocs/js/functions.js
@@ -116,6 +116,9 @@ vz.load = function(args, skipDefaultErrorHandling) {
 
 	args.url += '.json';
 
+	// workaround Safari 11 cache bug
+	args.url += '?unique=' + Date.now();
+
 	if (args.data === undefined) {
 		args.data = { };
 	}

--- a/htdocs/js/init.js
+++ b/htdocs/js/init.js
@@ -96,7 +96,7 @@ $(document).ready(function() {
 
 	// chaining ajax request with jquery deferred object
 	vz.capabilities.load().done(function() {
-		vz.entities.loadDetails().done(function() {
+		vz.entities.loadDetails().always(function() {
 			if (vz.entities.length === 0) {
 				vz.wui.dialogs.init();
 			}

--- a/lib/Util/EntityFactory.php
+++ b/lib/Util/EntityFactory.php
@@ -221,7 +221,7 @@ class EntityFactory {
 	 * @throws Exception
 	 */
 	private function cached($key, $cache, $callable) {
-		if ($cache && $this->cache->contains($key)) {
+		if ($cache && $this->cache->contains($key) && !Util\Configuration::read('devmode')) {
 			$entity = $this->cache->fetch($key);
 
 			if (!$entity instanceof Aggregator) {


### PR DESCRIPTION
Fixes:

  - caching problem with Safari 11
  - if one entity misses (e.g. deleted) page would not load
  - entity caching was still active in devmode
