### PR TITLE
Fix performance middleware persistent cache outdated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ matrix:
       env: DB= DEPENDENCIES= JSLINT=true
 
 notifications:
-    mail: "volkszaehler-dev@lists.volkszaehler.org"
+    email: "volkszaehler-dev@lists.volkszaehler.org"
     irc: "chat.freenode.net#volkszaehler.org"
 
 # speedup build

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,10 @@ matrix:
       env: DB=sqlite
     # httpd-based
     - php: 7.0
-      env: DB=mysql TEST_COMPONENT=HTTPD
+      env: DB=mysql COMPONENT=HTTPD
     # push-server
     - php: 7.0
-      env: DB=mysql TEST_COMPONENT=PUSH_SERVER
+      env: DB=mysql COMPONENT=PUSHD
     # from..to
     - php: 7.0
       env: DB=mysql DEPENDENCIES=lowest
@@ -95,14 +95,14 @@ before_script:
 
     # start middleware service
     - |
-      if [ "$TEST_COMPONENT" = "HTTPD" ]; then
+      if [ "$COMPONENT" = "HTTPD" ]; then
         sed -i "s/testAdapter\" value=\".*\"/testAdapter\" value=\"HTTP\"/" phpunit.xml
         vendor/bin/ppm start -c etc/middleware.json &
       fi
 
     # push server tests
     - |
-      if [ "$TEST_COMPONENT" = "PUSH_SERVER" ]; then
+      if [ "$COMPONENT" = "PUSHD" ]; then
         sed -i "s/\?>/\$config['push']['enabled']\ =\ true\;\n?>/" etc/volkszaehler.conf.php
         php misc/tools/push-server.php &
       fi
@@ -110,7 +110,7 @@ before_script:
 after_script:
     # stop middleware service
     - |
-      if [ "$TEST_COMPONENT" = "HTTPD" ]; then
+      if [ "$COMPONENT" = "HTTPD" ]; then
         vendor/bin/ppm stop -c etc/middleware.json
       fi
 
@@ -127,7 +127,7 @@ script:
       fi
 
     # push server tests
-    - if [ "$TEST_COMPONENT" = "PUSH_SERVER" ]; then vendor/bin/phpunit --group pushserver; fi
+    - if [ "$COMPONENT" = "PUSHD" ]; then vendor/bin/phpunit --group pushserver; fi
 
     # jslint javascript sources
     - if [ "$JSLINT" = true ]; then gulp jshint; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,11 @@ before_script:
       fi
 
 after_script:
-    - if [ "$TEST_COMPONENT" = "HTTPD" ]; then kill -9 $HTTPD_PID; fi
+    # stop middleware service
+    - |
+      if [ "$TEST_COMPONENT" = "HTTPD" ]; then
+        vendor/bin/ppm stop -c etc/middleware.json
+      fi
 
 script:
     # run core tests
@@ -128,8 +132,3 @@ script:
     # jslint javascript sources
     - if [ "$JSLINT" = true ]; then gulp jshint; fi
 
-    # stop middleware service
-    - |
-      if [ "$TEST_COMPONENT" = "HTTPD" ]; then
-        vendor/bin/ppm stop -c etc/middleware.json
-      fi

--- a/lib/Controller/AggregatorController.php
+++ b/lib/Controller/AggregatorController.php
@@ -83,7 +83,6 @@ class AggregatorController extends EntityController {
 		}
 
 		$this->em->flush();
-		$this->ef->remove($uuid);
 
 		return $aggregator;
 	}

--- a/lib/Definition/Definition.php
+++ b/lib/Definition/Definition.php
@@ -105,10 +105,10 @@ abstract class Definition {
 
 		$cache_id = static::CACHE_KEY . static::FILE;
 
-		if (Util\Configuration::read('devmode') == FALSE && extension_loaded('apc') && apc_exists($cache_id) &&
-			(time() - filemtime(__DIR__ . '/' . static::FILE) > Util\Configuration::read('cache.ttl')))
+		if (Util\Configuration::read('devmode') == FALSE && extension_loaded('apcu') && apcu_exists($cache_id) &&
+			(time() - filemtime(__DIR__ . '/' . static::FILE) > Util\Configuration::read('cache.ttl', 3600)))
 		{
-			static::$definitions = apc_fetch($cache_id);
+			static::$definitions = apcu_fetch($cache_id);
 		}
 		else {
 			// expensive - cache results
@@ -118,8 +118,8 @@ abstract class Definition {
 				static::$definitions[$property->name] = new static($property);
 			}
 
-			if (extension_loaded('apc')) {
-				apc_store($cache_id, static::$definitions, Util\Configuration::read('cache.ttl'));
+			if (extension_loaded('apcu')) {
+				apcu_store($cache_id, static::$definitions, Util\Configuration::read('cache.ttl', 3600));
 			}
 		}
 	}

--- a/lib/Router.php
+++ b/lib/Router.php
@@ -124,6 +124,10 @@ class Router implements HttpKernelInterface {
 			if (null == $this->em || !$this->em->isOpen() || $this->em->getConnection()->ping() === false) {
 				$this->em = self::createEntityManager();
 			}
+			else {
+				// clear to make sure it doesn't use its cache
+				$this->em->clear();
+			}
 
 			return $this->handleRaw($request, $type);
 		}

--- a/test/GroupTest.php
+++ b/test/GroupTest.php
@@ -70,14 +70,8 @@ class GroupTest extends Middleware
 		$this->getJson('/group/' . $child . '.json', array(
 			'operation' => 'delete'
 		));
-		
-		error_log("-- Travis debug --");
-		print_r($this->json);
-		$json = $this->getJson('/group/' . self::$uuid . '.json');
-		print_r($json);
-		
-		$this->assertObjectNotHasAttribute('children', $json->entity);
-//		$this->assertObjectNotHasAttribute('children', $this->getJson('/group/' . self::$uuid . '.json')->entity);
+
+		$this->assertObjectNotHasAttribute('children', $this->getJson('/group/' . self::$uuid . '.json')->entity);
 	}
 
 	/**


### PR DESCRIPTION
Without this fix the entity manager would not re-hit the database if it thinks it already knows the entity. This leads to performance middleware processes being blind for changes done by another process.

Observed during https://github.com/volkszaehler/volkszaehler.org/pull/656