### PR TITLE
Add global gap option

### DIFF
--- a/htdocs/js/options.js
+++ b/htdocs/js/options.js
@@ -54,6 +54,7 @@ vz.options = {
 	dayNames: ['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa'],
 	lineWidthDefault: 2,
 	lineWidthSelected: 4,
+	gap: 3600, // chart gap if no tuples for specified number of seconds
 	speedupFactor: 2,   // higher values give higher speedup but can produce chunky display
 	hiddenProperties: ['link', 'tolerance', 'local', 'owner', 'description', 'gap', 'active'] // hide less commonly used properties
 };

--- a/htdocs/js/wui.js
+++ b/htdocs/js/wui.js
@@ -897,17 +897,15 @@ vz.wui.drawPlot = function () {
 	var series = [];
 	vz.entities.each(function(entity) {
 		if (entity.isChannel() && entity.active && entity.data && entity.data.tuples && entity.data.tuples.length > 0) {
-			var i, maxTuples = 0;
-
 			// work on copy here to be able to redraw
-			var tuples = entity.data.tuples.map(function(t) {
+			var i, tuples = entity.data.tuples.map(function(t) {
 				return t.slice(0);
 			});
-
 
 			var style = vz.options.style || entity.style;
 			var fillstyle = parseFloat(vz.options.fillstyle || entity.fillstyle);
 			var linewidth = parseFloat(vz.options.linewidth || vz.options[entity.uuid == vz.wui.selectedChannel ? 'lineWidthSelected' : 'lineWidthDefault']);
+			var gap = vz.options.gap || entity.gap;
 
 			// mangle data for "steps" curves by shifting one ts left ("step-before")
 			if (style == "steps") {
@@ -920,7 +918,6 @@ vz.wui.drawPlot = function () {
 			// remove number of datapoints from each tuple to avoid flot fill error
 			if (fillstyle || entity.gap) {
 				for (i=0; i<tuples.length; i++) {
-					maxTuples = Math.max(maxTuples, tuples[i][2]);
 					delete tuples[i][2];
 				}
 			}
@@ -946,7 +943,7 @@ vz.wui.drawPlot = function () {
 			// disable interpolation when data has gaps
 			if (entity.gap) {
 				var minGapWidth = (entity.data.to - entity.data.from) / tuples.length;
-				serie.xGapThresh = Math.max(entity.gap * 1000 * maxTuples, minGapWidth);
+				serie.xGapThresh = Math.max(entity.gap * 1000, 2 * minGapWidth);
 				vz.options.plot.xaxis.insertGaps = true;
 			}
 

--- a/htdocs/js/wui.js
+++ b/htdocs/js/wui.js
@@ -897,9 +897,9 @@ vz.wui.drawPlot = function () {
 	var series = [];
 	vz.entities.each(function(entity) {
 		if (entity.isChannel() && entity.active && entity.data && entity.data.tuples && entity.data.tuples.length > 0) {
-			// work on copy here to be able to redraw
+			// work on deep copy here to be able to redraw
 			var i, tuples = entity.data.tuples.map(function(t) {
-				return t.slice(0);
+				return t.slice(0, 2);
 			});
 
 			var style = vz.options.style || entity.style;
@@ -912,13 +912,6 @@ vz.wui.drawPlot = function () {
 				tuples.unshift([entity.data.from, 1, 1]); // add new first ts
 				for (i=0; i<tuples.length-1; i++) {
 					tuples[i][1] = tuples[i+1][1];
-				}
-			}
-
-			// remove number of datapoints from each tuple to avoid flot fill error
-			if (fillstyle || entity.gap) {
-				for (i=0; i<tuples.length; i++) {
-					delete tuples[i][2];
 				}
 			}
 


### PR DESCRIPTION
Display a gap when data is not continuous. Global option allows to set default instead of specifying per channel. By default, no measurement for 1 hour will show as a gap. Set `gap=0` in `options.js` to disable.