### PR TITLE
fix for vzclient regarding user agent

### DIFF
--- a/bin/vzclient
+++ b/bin/vzclient
@@ -94,7 +94,7 @@ for p in args.param:
 
 
 opener = urllib2.build_opener()
-opener.addheaders = [('User-agent', 'vzclient_' + version)]
+opener.addheaders = [('User-agent', 'vzclient/' + version)]
 
 
 try:

--- a/bin/vzclient
+++ b/bin/vzclient
@@ -92,14 +92,17 @@ for p in args.param:
   url=url+"&"+urllib2.quote(key)+"="+urllib2.quote(value);
 # print url;
 
-req = urllib2.Request(url)
-req.add_header('User-agent', 'vzclient/$version')
+
+opener = urllib2.build_opener()
+opener.addheaders = [('User-agent', 'vzclient_' + version)]
+
+
 try:
   if (args.json):
-    req.add_header('Content-Type', 'application/json');
-    f=urllib2.urlopen(url, args.json);
+    opener.addheaders = [('Content-Type', 'application/json')];
+    f=opener.open(url, args.json);
   else:
-    f=urllib2.urlopen(url);
+    f=opener.open(url);
   jsonstr=f.read();
 
   # unparsed - json or other format


### PR DESCRIPTION
vzclient doesnt add the correct user agent information:
`127.0.0.1 - - [22/Oct/2018:11:04:11 +0200] "GET /middleware.php/channel.json?operation=get HTTP/1.1" 200 2269 "-" "Python-urllib/2.7"`

With this commit the apache log shows the correct user agent:
`127.0.0.1 - - [23/Oct/2018:07:59:05 +0200] "GET /middleware.php/channel.json?operation=get HTTP/1.1" 200 2269 "-" "vzclient_1.0"`

Please review and approve.
