### PR TITLE
fix php parse errors regarding access of static methods

### DIFF
--- a/lib/Interpreter/Interpreter.php
+++ b/lib/Interpreter/Interpreter.php
@@ -109,7 +109,7 @@ abstract class Interpreter implements \IteratorAggregate {
 		$this->optimizer = new $class($this);
 
 		// value filters
-		$this->sqlValueFilter = $this->optimizer::buildValueFilterSQL($filters, $this->sqlValueFilterParams);
+		$this->sqlValueFilter = $this->optimizer->buildValueFilterSQL($filters, $this->sqlValueFilterParams);
 
 		if ($this->hasOption('nocache')) {
 			$this->optimizer->disableCache();
@@ -212,11 +212,11 @@ abstract class Interpreter implements \IteratorAggregate {
 
 		// common conditions for following SQL queries
 		$sqlParameters = array($this->channel->getId());
-		$sqlTimeFilter = $this->optimizer::buildDateTimeFilterSQL($this->from, $this->to, $sqlParameters);
+		$sqlTimeFilter = $this->optimizer->buildDateTimeFilterSQL($this->from, $this->to, $sqlParameters);
 		$sqlParameters = array_merge($sqlParameters, $this->sqlValueFilterParams);
 
 		if ($this->groupBy) {
-			$sqlGroupFields = $this->optimizer::buildGroupBySQL($this->groupBy);
+			$sqlGroupFields = $this->optimizer->buildGroupBySQL($this->groupBy);
 			if (!$sqlGroupFields)
 				throw new \Exception('Unknown group');
 

--- a/lib/Interpreter/SQL/MySQLAggregateOptimizer.php
+++ b/lib/Interpreter/SQL/MySQLAggregateOptimizer.php
@@ -169,7 +169,7 @@ class MySQLAggregateOptimizer extends MySQLOptimizer {
 					// add common aggregation and sorting on UNIONed table
 					// (sorting applied outside UNION as MySQL doesn't guarantee UNION result ordering)
 					$sql = 'SELECT MAX(timestamp) AS timestamp, ' .
-							$this->interpreter::groupExprSQL('value') . ' AS value, SUM(count) AS count ' .
+							$this->interpreter->groupExprSQL('value') . ' AS value, SUM(count) AS count ' .
 						   'FROM (' . $sql . ') AS agg ' .
 						   'GROUP BY ' . $sqlGroupFields . ' ORDER BY timestamp ASC';
 				}

--- a/lib/Interpreter/SQL/MySQLOptimizer.php
+++ b/lib/Interpreter/SQL/MySQLOptimizer.php
@@ -115,7 +115,7 @@ class MySQLOptimizer extends SQLOptimizer {
 			'SELECT MAX(agg.timestamp) AS timestamp, ' .
 				  'COALESCE( ' .
 					  'SUM(agg.val_by_time) / (MAX(agg.timestamp) - MIN(agg.prev_timestamp)), ' .
-					  $this->interpreter::groupExprSQL('agg.value') .
+					  $this->interpreter->groupExprSQL('agg.value') .
 				  ') AS value, ' .
 				  'COUNT(agg.value) AS count ' .
 		   'FROM ( ' .

--- a/lib/Interpreter/SQL/SQLOptimizer.php
+++ b/lib/Interpreter/SQL/SQLOptimizer.php
@@ -231,7 +231,7 @@ abstract class SQLOptimizer {
 			$sqlTimeFilter = self::buildDateTimeFilterSQL($this->from, $this->to, $foo);
 
 			$sql = 'SELECT MAX(agg.timestamp) AS timestamp, ' .
-						   $this->interpreter::groupExprSQL('agg.value') . ' AS value, ' .
+						   $this->interpreter->groupExprSQL('agg.value') . ' AS value, ' .
 						  'COUNT(agg.value) AS count ' .
 				   'FROM (' .
 						 'SELECT timestamp, value ' .


### PR DESCRIPTION
This fixes several error messages like this:
PHP Parse error:  syntax error, unexpected '::' (T_PAAMAYIM_NEKUDOTAYIM)
in /var/www/volkszaehler.org/lib/Interpreter/SQL/MySQLAggregateOptimizer.php
on line 211

Seen this on a debian stretch installation which contains php7.0.
This are probably not all occasions if this problem, but the ones
resulting in php errors and where the fix was tested.