### PR TITLE
Add /query and /prognosis context and tests

### DIFF
--- a/lib/Controller/PrognosisController.php
+++ b/lib/Controller/PrognosisController.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * @author Andreas Goetz <cpuidle@gmx.de>
+ * @copyright Copyright (c) 2011-2019, The volkszaehler.org project
+ * @license http://www.opensource.org/licenses/gpl-license.php GNU Public License
+ */
+/*
+ * This file is part of volkzaehler.org
+ *
+ * volkzaehler.org is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * volkzaehler.org is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with volkszaehler.org. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Volkszaehler\Controller;
+
+use Symfony\Component\HttpFoundation\Request;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\ORMException;
+
+use Volkszaehler\Model;
+use Volkszaehler\Util;
+use Volkszaehler\Interpreter\Interpreter;
+use Volkszaehler\View\View;
+
+/**
+ * Prognosis controller
+ *
+ * @author Andreas Goetz <cpuidle@gmx.de>
+ */
+class PrognosisController extends DataController {
+
+	/**
+	 * Create and populate an interpreter
+	 *
+	 * @param string $uuid
+	 * @param string|int $from
+	 * @param string|int $to
+	 * @param string|null $groupBy
+	 */
+	private function populate($uuid, $from, $to, $groupBy = null) {
+		$entity = $this->ef->get($uuid, true); // from cache
+		$class = $entity->getDefinition()->getInterpreter();
+		$interpreter = new $class($entity, $this->em, $from, $to, null, $groupBy, $this->options);
+
+		foreach ($interpreter as $tuple) {
+			// loop through iterator tuples to retrieve data
+		}
+
+		return $interpreter;
+	}
+
+	/**
+	 * Query for data by given channel or group or multiple channels
+	 *
+	 * @param string|array $uuid
+	 * @return array
+	 */
+	public function get($uuid) {
+		$period = $this->getParameters()->get('period');
+		$groupBy = $this->getParameters()->get('group');
+		$now = $this->getParameters()->get('now');
+
+		// specifing "now" can be used for testing purposes to give refence
+		$partial = $now ? $now : 'now';
+		$format = 'd.m.Y';
+
+		switch ($period) {
+			case 'year':
+				$from = 'first day of january this year';
+				$to = 'last day of december this year';
+				break;
+			case 'month':
+				$from = 'first day of this month';
+				$to = 'last day of this month';
+				break;
+			case 'day':
+				$from = 'today';
+				$to = 'tomorrow';
+				$format = 'd.m.Y H:i:s';
+				break;
+			default:
+        		throw new \Exception('Unsupported period: \'' . $period . '\'');
+		}
+
+		// calculate reference period
+		foreach (array('from', 'partial', 'to') as $var) {
+			$reference_var = 'reference_' . $var;
+			$$reference_var = $$var . ' -1 ' . $period;
+		}
+
+		// iterate through interpreters
+		$current = $this->populate($uuid, $from, $partial, $groupBy);
+		$ref_partial = $this->populate($uuid, $reference_from, $reference_partial, $groupBy);
+		$ref_period = $this->populate($uuid, $reference_from, $reference_to, $groupBy);
+
+		// get consumption values
+		$current_consumption = $current->getConsumption();
+		$ref_partial_consumption = $ref_partial->getConsumption();
+		$ref_period_consumption = $ref_period->getConsumption();
+
+		// actual forecast/prognosis
+		if ($ref_partial_consumption) {
+			$factor = $current_consumption / $ref_partial_consumption;
+			$prognosis = $ref_period_consumption * $factor;
+		}
+		else {
+			$factor = null;
+			$prognosis = null;
+		}
+
+		// result
+		return array(
+			'prognosis' => array(
+				'from' => date($format, strtotime($from)),
+				'to' => date($format, strtotime($to)),
+				'consumption' => $prognosis,
+				'factor' => $factor,
+			),
+			'periods' => array(
+				'current' => array(
+					'from' => date($format, strtotime($from)),
+					'partial' => date($format, strtotime($partial)),
+					'partial_consumption' => $current_consumption
+				),
+				'reference' => array(
+					'from' => date($format, strtotime($reference_from)),
+					'partial' => date($format, strtotime($reference_partial)),
+					'to' => date($format, strtotime($reference_to)),
+					'partial_consumption' => $ref_partial_consumption,
+					'consumption' => $ref_period_consumption,
+				),
+			)
+		);
+	}
+
+	/*
+	 * Override inherited visibility
+	 */
+
+	public function add($uuid) {
+		throw new \Exception('Invalid context operation: \'add\'');
+	}
+
+	public function delete($uuids) {
+		throw new \Exception('Invalid context operation: \'delete\'');
+	}
+}
+
+?>

--- a/lib/Controller/QueryController.php
+++ b/lib/Controller/QueryController.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * @copyright Copyright (c) 2011-2019, The volkszaehler.org project
+ * @license http://www.opensource.org/licenses/gpl-license.php GNU Public License
+ */
+/*
+ * This file is part of volkzaehler.org
+ *
+ * volkzaehler.org is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * volkzaehler.org is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with volkszaehler.org. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Volkszaehler\Controller;
+
+use Symfony\Component\HttpFoundation\Request;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\ORMException;
+
+use Volkszaehler\Model;
+use Volkszaehler\Util;
+use Volkszaehler\Interpreter\Interpreter;
+use Volkszaehler\View\View;
+
+/**
+ * Prognose controller
+ *
+ * @author Andreas Goetz <cpuidle@gmx.de>
+ */
+class QueryController extends DataController {
+
+	/**
+	 * Create channel dynamically
+	 */
+	public static function channelFactory($type, $rule, $inputs) {
+		$channel = new Model\Channel($type);
+		$channel->setProperty('rule', $rule);
+
+		foreach ($inputs as $key => $value) {
+			if (is_numeric($key)) {
+				$key = 'in' . ($key+1);
+			}
+			$channel->setProperty($key, $value);
+		}
+
+		return $channel;
+	}
+
+	/**
+	 * Query for data by given channel or group or multiple channels
+	 *
+	 * @param string|array|null $uuid
+	 * @return array
+	 */
+	public function get($uuid) {
+		if (isset($uuid)) {
+			throw new \Exception('Queries cannot be performed against UUIDs');
+		}
+
+		$from = $this->getParameters()->get('from');
+		$to = $this->getParameters()->get('to');
+		$tuples = $this->getParameters()->get('tuples');
+		$groupBy = $this->getParameters()->get('group');
+
+		// dynamic properties
+		$type = $this->getParameters()->has('type') ? $this->getParameters()->get('type') : 'virtualsensor';
+		$rule = $this->getParameters()->get('rule');
+
+		$inputs = array();
+		for ($i=1; $i<10; $i++) {
+			$key = 'in' . $i;
+			if ($this->getParameters()->has($key)) {
+				$inputs[$key] = $this->getParameters()->get($key);
+			}
+		}
+
+		$entity = self::channelFactory($type, $rule, $inputs);
+		$class = $entity->getDefinition()->getInterpreter();
+		return new $class($entity, $this->em, $from, $to, $tuples, $groupBy, $this->options);
+	}
+
+	/*
+	 * Override inherited visibility
+	 */
+
+	public function add($uuid) {
+		throw new \Exception('Invalid context operation: \'add\'');
+	}
+
+	public function delete($uuids) {
+		throw new \Exception('Invalid context operation: \'delete\'');
+	}
+}
+
+?>

--- a/lib/Router.php
+++ b/lib/Router.php
@@ -75,6 +75,8 @@ class Router implements HttpKernelInterface {
 		'aggregator'	=> 'Volkszaehler\Controller\AggregatorController',
 		'entity'		=> 'Volkszaehler\Controller\EntityController',
 		'data'			=> 'Volkszaehler\Controller\DataController',
+		'query'			=> 'Volkszaehler\Controller\QueryController',
+		'prognosis'		=> 'Volkszaehler\Controller\PrognosisController',
 		'capabilities'	=> 'Volkszaehler\Controller\CapabilitiesController',
 		'iot'			=> 'Volkszaehler\Controller\IotController'
 	);

--- a/test/PrognosisTest.php
+++ b/test/PrognosisTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Prognosis controller tests
+ *
+ * @author Andreas Götz <cpuidle@gmx.de>
+ * @copyright Copyright (c) 2011-2018, The volkszaehler.org project
+ * @license https://www.gnu.org/licenses/gpl-3.0.txt GNU General Public License version 3
+ */
+
+namespace Tests;
+
+class PrognosisTest extends Data
+{
+	function testPrognosisException() {
+		$this->getJson('/prognosis.json', [], 'GET', "Unsupported period: ''");
+	}
+
+    function testDailyPrognosis() {
+		self::$uuid = self::createChannel('Sensor', 'powersensor');
+
+		$yesterday = 1000 * strtotime('yesterday');
+		$today = 1000 * strtotime('today');
+
+		// yesterday
+		$this->addTuple($yesterday, 0);
+		$this->addTuple($yesterday + 1 * 3.6e6, 10); // 01:00
+		$this->addTuple($yesterday + 1 * 3.6e6 + 1, 10); // 01:00 (stop for reference period)
+		$this->addTuple($yesterday + 2 * 3.6e6, 20); // 02:00
+
+		// today
+		$this->addTuple($today, 0); // 00:00
+		$this->addTuple($today+1, 0); // 01:00 (stop for current period)
+		$this->addTuple($today + 1 * 3.6e6, 5); // 01:00
+
+		$this->getJson('/prognosis/' . static::$uuid . '.json', [
+			'period' => 'day',
+			'now' => strftime('%X', ($today + 1 * 3.6e6) / 1e3),
+		]);
+
+        $this->assertEquals(15, $this->json->prognosis->consumption);
+        $this->assertEquals(0.5, $this->json->prognosis->factor);
+        $this->assertEquals(5, $this->json->periods->current->partial_consumption);
+        $this->assertEquals(10, $this->json->periods->reference->partial_consumption);
+        $this->assertEquals(30, $this->json->periods->reference->consumption);
+    }
+}
+
+?>

--- a/test/QueryTest.php
+++ b/test/QueryTest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Query controller tests
+ *
+ * @author Andreas Götz <cpuidle@gmx.de>
+ * @copyright Copyright (c) 2011-2018, The volkszaehler.org project
+ * @license https://www.gnu.org/licenses/gpl-3.0.txt GNU General Public License version 3
+ */
+
+namespace Tests;
+
+class QueryTest extends Data
+{
+	function testQueryException() {
+		$this->getJson('/query/uuid.json', [], 'GET', 'Queries cannot be performed against UUIDs');
+	}
+
+    function testAdhocQuery() {
+		self::$uuid = self::createChannel('Sensor', 'powersensor');
+
+		$this->addTuple(3600, 0);
+		$this->addTuple(7200, $value = 7);
+
+		$this->getJson('/query.json', [
+			'in1' => static::$uuid,
+			'rule' => '2*in1()',
+		]);
+
+        $this->assertCount(1, $this->json->data->tuples);
+        $this->assertEquals(2 * $value, $this->json->data->tuples[0][1]);
+    }
+}
+
+?>


### PR DESCRIPTION
This PR brings the following features:

- add `/query` context for executing ad-hoc queries using virtual channel capabilities
- add `/prognosis` context for executing consumption forecast by using reference period

Prognosis looks like this:

    /prognosis.json?period=day

result:

    [version] => 0.3
    [prognosis] => [
        [from] => 13.03.2019 00:00:00
        [to] => 14.03.2019 00:00:00
        [consumption] => 15
        [factor] => 0.5
    ]
    [periods] => [
        [current] => [
            [from] => 13.03.2019 00:00:00
            [partial] => 13.03.2019 01:00:00
            [partial_consumption] => 5
        ]
        [reference] => [   
            [from] => 12.03.2019 00:00:00
            [partial] => 12.03.2019 01:00:00
            [to] => 13.03.2019 00:00:00
            [partial_consumption] => 10
            [consumption] => 30
        ]
    ]
    