### PR TITLE
Let middleware speedup queries when desired tuple count is specified

### DIFF
--- a/htdocs/js/entities.js
+++ b/htdocs/js/entities.js
@@ -121,27 +121,6 @@ vz.entities.loadTotalConsumption = function() {
 };
 
 /**
- * Speedup middleware queries, requires options[aggregate] enabled
- * @return {string} group option or undefined
- */
-vz.entities.speedupFactor = function() {
-	var	group = vz.options.group,
-		delta = (vz.options.plot.xaxis.max - vz.options.plot.xaxis.min) / 3.6e6;
-
-	// explicit group set via url?
-	if (group !== undefined)
-		return group;
-
-	if (delta > 24 * vz.options.tuples/vz.options.speedupFactor) {
-		group = 'day';
-	}
-	else if (delta > vz.options.tuples/vz.options.speedupFactor) {
-		group = 'hour';
-	}
-	return group;
-};
-
-/**
  * Overwritten each iterator to iterate recursively through all entities
  */
 vz.entities.each = function(cb, recursive) {

--- a/htdocs/js/entity.js
+++ b/htdocs/js/entity.js
@@ -378,7 +378,7 @@ Entity.prototype.loadData = function () {
 				: vz.options.tuples,
 			group: this.isConsumptionMode()
 				? vz.options.mode // mode contains the desired grouping
-				: vz.entities.speedupFactor(),
+				: vz.options.group,
 			options: this.isConsumptionMode()
 				? 'consumption'
 				: vz.options.options

--- a/htdocs/js/options.js
+++ b/htdocs/js/options.js
@@ -55,7 +55,6 @@ vz.options = {
 	lineWidthDefault: 2,
 	lineWidthSelected: 4,
 	gap: 3600, // chart gap if no tuples for specified number of seconds
-	speedupFactor: 2,   // higher values give higher speedup but can produce chunky display
 	hiddenProperties: ['link', 'tolerance', 'local', 'owner', 'description', 'gap', 'active'] // hide less commonly used properties
 };
 


### PR DESCRIPTION
This PR should give a *huge* performance improvements for any non-frontend queries that specify desired tuple count. Even when not adding `group` parameter, the middleware will automatically determine best grouping ("chunkyness" can be tweaked using `speedup` config option) and therefore enable aggregation usage.