### PR TITLE
change luminosity unit to lux

### DIFF
--- a/lib/Definition/EntityDefinition.json
+++ b/lib/Definition/EntityDefinition.json
@@ -400,7 +400,7 @@
 		"name"			: "luminosity",
 		"optional"		: ["resolution"],
 		"icon"			: "sun.png",
-		"unit"			: "cd",
+		"unit"			: "lx",
 		"interpreter"		: "Volkszaehler\\Interpreter\\SensorInterpreter",
 		"model"			: "Volkszaehler\\Model\\Channel",
 		"translation"		: {


### PR DESCRIPTION
lumen (lm) describes how much light is *sent out* to all directions.
candela (cd) describes how much light is *sent out* in a defined direction.
lux (lx) describes how much light *arrives* on a specific surface.

lux is better as sensor unit

src: https://www.wirsindheller.de/Begriffe-in-der-Lichtmessung.28.0.html