### PR TITLE
 Zoom for mobile page based on cursor position. closes volkszaehler/volkszaehler.org#671

### DIFF
--- a/htdocs/js/wui.js
+++ b/htdocs/js/wui.js
@@ -551,11 +551,19 @@ vz.wui.initEvents = function() {
  * @param ev either click event or literal button event value
  */
 vz.wui.handleControls = function(action, keepPeriodStartFixed) {
-	var delta = vz.options.plot.xaxis.max - vz.options.plot.xaxis.min,
-			middle = vz.options.plot.xaxis.min + delta/2,
-			startOfPeriodLocale;
-
+	var delta   = vz.options.plot.xaxis.max - vz.options.plot.xaxis.min;
+	var middle  = vz.options.plot.xaxis.min + delta/2;
+	var hover;
+	var startOfPeriodLocale;
 	var control = typeof action == 'string' ? action : $(this).val();
+	var axes    = vz.plot.getAxes();
+
+	if (vz.options.plot.hoverPos &&
+	    !(vz.options.plot.hoverPos.x < axes.xaxis.min || vz.options.plot.hoverPos.x > axes.xaxis.max ||
+	      vz.options.plot.hoverPos.y < axes.yaxis.min || vz.options.plot.hoverPos.y > axes.yaxis.max))
+	{
+		hover = vz.options.plot.hoverPos.x;
+	}
 
 	switch (control) {
 		case 'move-last':
@@ -614,17 +622,26 @@ vz.wui.handleControls = function(action, keepPeriodStartFixed) {
 			break;
 		case 'zoom-in':
 			vz.wui.period = null;
-			if (vz.wui.tmaxnow)
+			if (hover)
+				vz.wui.zoom(hover - delta/4, hover + delta/4);
+			else if (vz.wui.tmaxnow)
 				vz.wui.zoom(moment().valueOf() - delta/2, moment().valueOf());
 			else
 				vz.wui.zoom(middle - delta/4, middle + delta/4);
 			break;
 		case 'zoom-out':
 			vz.wui.period = null;
-			vz.wui.zoom(
-				middle - delta,
-				middle + delta
-			);
+			if (hover)
+				vz.wui.zoom(
+					hover - delta,
+					hover + delta
+				);
+			else
+				vz.wui.zoom(
+					middle - delta,
+					middle + delta
+				);
+
 			break;
 		case 'zoom-hour':
 		case 'zoom-day':


### PR DESCRIPTION
Depend the zoom based on the last hover position. For mobile devices the hover position is set when tap on the chart and is persistant. For normal browsers the hover is done by the mouse and invalid when moving out of the area. Thus the cange only affect mobile devices.