### PR TITLE
add entity definition illumination with unit lux

### DIFF
--- a/lib/Definition/EntityDefinition.json
+++ b/lib/Definition/EntityDefinition.json
@@ -410,6 +410,18 @@
 		}
 	},
 	{
+		"name"			: "illumination",
+		"optional"		: ["resolution"],
+		"icon"			: "sun.png",
+		"unit"			: "lx",
+		"interpreter"		: "Volkszaehler\\Interpreter\\SensorInterpreter",
+		"model"			: "Volkszaehler\\Model\\Channel",
+		"translation"		: {
+			"de" : "Beleuchtungsstärke",
+			"en" : "Illumination"
+		}
+	},
+	{
 		"name"			: "frequency",
 		"optional"		: ["resolution"],
 		"icon"			: "freq.png",


### PR DESCRIPTION
lumen (lm) describes how much light is *sent out* to all directions.
candela (cd) describes how much light is *sent out* in a defined direction.
lux (lx) describes how much light *arrives* on a specific surface.

lux is better for light sensors

src: https://www.wirsindheller.de/Begriffe-in-der-Lichtmessung.28.0.html

see also https://github.com/volkszaehler/volkszaehler.org/pull/769