### PR TITLE
add entity definition batterylevel with unit %

### DIFF
--- a/lib/Definition/EntityDefinition.json
+++ b/lib/Definition/EntityDefinition.json
@@ -139,6 +139,18 @@
 		}
 	},
 	{
+		"name"			: "batterylevel",
+		"optional"		: ["resolution"],
+		"icon"			: "bolt.png",
+		"unit"			: "%",
+		"interpreter"		: "Volkszaehler\\Interpreter\\SensorInterpreter",
+		"model"			: "Volkszaehler\\Model\\Channel",
+		"translation"		: {
+			"de" : "Batteriestand",
+			"en" : "Battery Level"
+		}
+	},
+	{
 		"name"			: "gas",
 		"required"		: ["resolution"],
 		"optional"		: [],


### PR DESCRIPTION
e.g. for battery driven sensors
like Aqara RTCGQ11LM motion sensor
https://www.zigbee2mqtt.io/devices/RTCGQ11LM