### PR TITLE
webhost compatibility

### DIFF
--- a/htdocs/.htaccess
+++ b/htdocs/.htaccess
@@ -17,8 +17,10 @@
 
 <IfModule mod_rewrite.c>
 	RewriteEngine On
-	RewriteRule ^middleware(/.*)? middleware.php$1 [L]
-	RewriteRule ^api(/.*)? middleware.php$1 [L]
+	RewriteBase /
+	RewriteCond %{REQUEST_FILENAME} !-f 
+	RewriteRule ^middleware(/.*)? middleware.php$1 [R,L]
+	RewriteRule ^api(/.*)? middleware.php$1 [R,L]
 
 	# frontend alias
 	RewriteRule ^frontend/(.*) $1 [L]


### PR DESCRIPTION
On webhosting the rewrite didn't quite work. The server delivered "No input file specified." or "403 Forbidden".
I tested this on Rpi with Apache2, but not docker.