### PR TITLE
make usage of aggregation data more efficient for mysql

### DIFF
--- a/lib/Interpreter/SQL/MySQLAggregateOptimizer.php
+++ b/lib/Interpreter/SQL/MySQLAggregateOptimizer.php
@@ -81,7 +81,7 @@ class MySQLAggregateOptimizer extends MySQLOptimizer {
 			$levels = Util\Aggregation::getAggregationLevels();
 			$level = $this->groupBy ? Util\Aggregation::getAggregationLevelTypeValue($this->groupBy) : -1;
 			while ($level >= 0 && !$this->aggValid) {
-				$aggregationLevels = $this->aggregator->getOptimalAggregationLevel($this->channel->getUuid(), $levels[$level], $this->from, $this->to);
+				$aggregationLevels = $this->aggregator->hasDataForAggregationLevel($this->channel->getUuid(), $levels[$level], $this->from, $this->to);
 
 				if ($aggregationLevels) {
 					// choose highest level

--- a/lib/Interpreter/SQL/MySQLAggregateOptimizer.php
+++ b/lib/Interpreter/SQL/MySQLAggregateOptimizer.php
@@ -70,7 +70,9 @@ class MySQLAggregateOptimizer extends MySQLOptimizer {
 	/**
 	 * Validate use of aggregation table
 	 *
-	 * 	1. find matching aggregation level <= $this->groupBy or highest level
+	 * 	1. find matching aggregation level <= $this->groupBy or highest level by iterating
+	 *	   Aggregation::$aggregationLevels in reverse order starting with highest possible
+	 *	   level or $this->groupBy
 	 * 	2. calculate if matching timestamps found
 	 *
 	 * @return boolean	Aggregation table usage validity

--- a/lib/Interpreter/SQL/MySQLAggregateOptimizer.php
+++ b/lib/Interpreter/SQL/MySQLAggregateOptimizer.php
@@ -80,7 +80,7 @@ class MySQLAggregateOptimizer extends MySQLOptimizer {
 			$this->aggValid = false;
 			$levels = Util\Aggregation::getAggregationLevels();
 			$level = $this->groupBy ? Util\Aggregation::getAggregationLevelTypeValue($this->groupBy) : -1;
-			while($level >= 0 and !$this->aggValid) {
+			while ($level >= 0 && !$this->aggValid) {
 				$aggregationLevels = $this->aggregator->getOptimalAggregationLevel($this->channel->getUuid(), $levels[$level], $this->from, $this->to);
 
 				if ($aggregationLevels) {

--- a/lib/Interpreter/SQL/MySQLAggregateOptimizer.php
+++ b/lib/Interpreter/SQL/MySQLAggregateOptimizer.php
@@ -80,16 +80,17 @@ class MySQLAggregateOptimizer extends MySQLOptimizer {
 	private function validateAggregationUsage() {
 		if ($this->aggValid === null) {
 			$this->aggValid = false;
-			$aggType = $this->groupBy ? Util\Aggregation::getAggregationLevelTypeValue($this->groupBy) : max(array_keys(Util\Aggregation::getAggregationLevels()));
+			$levels = Util\Aggregation::getAggregationLevels();
+			$aggType = $this->groupBy ? Util\Aggregation::getAggregationLevelTypeValue($this->groupBy) : max(array_keys($levels));
 			while ($aggType >= 0 && !$this->aggValid) {
-				$aggregationLevels = $this->aggregator->hasDataForAggregationLevel($this->channel->getUuid(), $aggType, $this->from, $this->to);
+				$aggregationType = $this->aggregator->hasDataForAggregationLevel($this->channel->getUuid(), $aggType, $this->from, $this->to);
 
-				if ($aggregationLevels) {
-					// choose highest level
-					$this->aggLevel = $aggregationLevels[0]['level'];
+				if ($aggregationType) {
+					// set name of level
+					$this->aggLevel = $levels[$aggregationType];
 
-					// numeric value of desired aggregation level
-					$this->aggType = Util\Aggregation::getAggregationLevelTypeValue($this->aggLevel);
+					// numeric value of aggregation level
+					$this->aggType = $aggregationType;
 
 					// valid boundaries?
 					$this->aggValid = $this->getAggregationBoundary();

--- a/lib/Interpreter/SQL/MySQLAggregateOptimizer.php
+++ b/lib/Interpreter/SQL/MySQLAggregateOptimizer.php
@@ -79,7 +79,7 @@ class MySQLAggregateOptimizer extends MySQLOptimizer {
 		if ($this->aggValid === null) {
 			$this->aggValid = false;
 			$levels = Util\Aggregation::getAggregationLevels();
-			$level = $this->groupBy ? Util\Aggregation::getAggregationLevelTypeValue($this->groupBy) : -1;
+			$level = $this->groupBy ? Util\Aggregation::getAggregationLevelTypeValue($this->groupBy) : max(array_keys($levels));
 			while ($level >= 0 && !$this->aggValid) {
 				$aggregationLevels = $this->aggregator->hasDataForAggregationLevel($this->channel->getUuid(), $levels[$level], $this->from, $this->to);
 

--- a/lib/Interpreter/SQL/MySQLAggregateOptimizer.php
+++ b/lib/Interpreter/SQL/MySQLAggregateOptimizer.php
@@ -80,10 +80,9 @@ class MySQLAggregateOptimizer extends MySQLOptimizer {
 	private function validateAggregationUsage() {
 		if ($this->aggValid === null) {
 			$this->aggValid = false;
-			$levels = Util\Aggregation::getAggregationLevels();
-			$level = $this->groupBy ? Util\Aggregation::getAggregationLevelTypeValue($this->groupBy) : max(array_keys($levels));
-			while ($level >= 0 && !$this->aggValid) {
-				$aggregationLevels = $this->aggregator->hasDataForAggregationLevel($this->channel->getUuid(), $levels[$level], $this->from, $this->to);
+			$aggType = $this->groupBy ? Util\Aggregation::getAggregationLevelTypeValue($this->groupBy) : max(array_keys(Util\Aggregation::getAggregationLevels()));
+			while ($aggType >= 0 && !$this->aggValid) {
+				$aggregationLevels = $this->aggregator->hasDataForAggregationLevel($this->channel->getUuid(), $aggType, $this->from, $this->to);
 
 				if ($aggregationLevels) {
 					// choose highest level
@@ -95,7 +94,7 @@ class MySQLAggregateOptimizer extends MySQLOptimizer {
 					// valid boundaries?
 					$this->aggValid = $this->getAggregationBoundary();
 				}
-				$level--;
+				$aggType--;
 			}
 		}
 

--- a/lib/Util/Aggregation.php
+++ b/lib/Util/Aggregation.php
@@ -127,7 +127,7 @@ class Aggregation {
 	 * @param  string  $targetLevel desired highest level (e.g. 'day')
 	 * @return array|boolean list of valid aggregation levels
 	 */
-	public function getOptimalAggregationLevel($uuid, $targetLevel = null, $from = null, $to = null) {
+	public function hasDataForAggregationLevel($uuid, $targetLevel = null, $from = null, $to = null) {
 		$levels = self::getAggregationLevels();
 
 		$sqlParameters = array($uuid);

--- a/lib/Util/Aggregation.php
+++ b/lib/Util/Aggregation.php
@@ -127,15 +127,15 @@ class Aggregation {
 	 * @param  string  $targetLevel desired highest level (e.g. 'day')
 	 * @return array|boolean list of valid aggregation levels
 	 */
-	public function hasDataForAggregationLevel($uuid, $targetLevel = null, $from = null, $to = null) {
+	public function hasDataForAggregationLevel($uuid, $targetAggType = null, $from = null, $to = null) {
 		$levels = self::getAggregationLevels();
 
 		$sqlParameters = array($uuid);
 		$sql = 'SELECT aggregate.type, COUNT(aggregate.id) AS count ' .
 			   'FROM aggregate INNER JOIN entities ON aggregate.channel_id = entities.id ' .
 			   'WHERE uuid = ? ';
-		if ($targetLevel) {
-			$sqlParameters[] = self::getAggregationLevelTypeValue($targetLevel);
+		if ($targetAggType) {
+			$sqlParameters[] = $targetAggType;
 			$sql .= 'AND aggregate.type = ? ';
 		}
 		if (isset($from)) {

--- a/lib/Util/Aggregation.php
+++ b/lib/Util/Aggregation.php
@@ -138,11 +138,11 @@ class Aggregation {
 			$sqlParameters[] = self::getAggregationLevelTypeValue($targetLevel);
 			$sql .= 'AND aggregate.type = ? ';
 		}
-		if ($from) {
+		if (isset($from)) {
 			$sqlParameters[] = $from;
 			$sql .= 'AND timestamp >= ? ';
 		}
-		if ($to) {
+		if (isset($to)) {
 			$sqlParameters[] = $to;
 			$sql .= 'AND timestamp <= ? ';
 		}

--- a/lib/Util/Aggregation.php
+++ b/lib/Util/Aggregation.php
@@ -127,7 +127,7 @@ class Aggregation {
 	 * @param  string  $targetLevel desired highest level (e.g. 'day')
 	 * @return array|boolean list of valid aggregation levels
 	 */
-	public function getOptimalAggregationLevel($uuid, $targetLevel = null) {
+	public function getOptimalAggregationLevel($uuid, $targetLevel = null, $from = null, $to = null) {
 		$levels = self::getAggregationLevels();
 
 		$sqlParameters = array($uuid);
@@ -136,7 +136,15 @@ class Aggregation {
 			   'WHERE uuid = ? ';
 		if ($targetLevel) {
 			$sqlParameters[] = self::getAggregationLevelTypeValue($targetLevel);
-			$sql .= 'AND aggregate.type <= ? ';
+			$sql .= 'AND aggregate.type = ? ';
+		}
+		if ($from) {
+			$sqlParameters[] = $from;
+			$sql .= 'AND timestamp >= ? ';
+		}
+		if ($to) {
+			$sqlParameters[] = $to;
+			$sql .= 'AND timestamp <= ? ';
 		}
 		$sql.= 'GROUP BY type ' .
 			   'HAVING count > 0 ' .

--- a/lib/Util/Aggregation.php
+++ b/lib/Util/Aggregation.php
@@ -125,19 +125,14 @@ class Aggregation {
 	 * Simple optimizer - choose aggregation level with most data available
 	 *
 	 * @param  string  $targetLevel desired highest level (e.g. 'day')
-	 * @return array|boolean list of valid aggregation levels
+	 * @return integer|boolean aggregation type
 	 */
-	public function hasDataForAggregationLevel($uuid, $targetAggType = null, $from = null, $to = null) {
-		$levels = self::getAggregationLevels();
+	public function hasDataForAggregationLevel($uuid, $targetAggType, $from = null, $to = null) {
 
-		$sqlParameters = array($uuid);
-		$sql = 'SELECT aggregate.type, COUNT(aggregate.id) AS count ' .
+	    $sqlParameters = array($uuid, $targetAggType);
+		$sql = 'SELECT aggregate.type ' .
 			   'FROM aggregate INNER JOIN entities ON aggregate.channel_id = entities.id ' .
-			   'WHERE uuid = ? ';
-		if ($targetAggType) {
-			$sqlParameters[] = $targetAggType;
-			$sql .= 'AND aggregate.type = ? ';
-		}
+			   'WHERE uuid = ? and aggregate.type = ? ';
 		if (isset($from)) {
 			$sqlParameters[] = $from;
 			$sql .= 'AND timestamp >= ? ';
@@ -146,18 +141,11 @@ class Aggregation {
 			$sqlParameters[] = $to;
 			$sql .= 'AND timestamp <= ? ';
 		}
-		$sql.= 'GROUP BY type ' .
-			   'HAVING count > 0 ' .
-			   'ORDER BY type DESC';
+		$sql.= 'LIMIT 1';
 
 		$rows = $this->conn->fetchAll($sql, $sqlParameters);
 
-		// append readable level name
-		for ($i=0; $i<count($rows); $i++) {
-			$rows[$i]['level'] = $levels[$rows[$i]['type']];
-		}
-
-		return count($rows) ? $rows : FALSE;
+		return count($rows) ? $rows[0]['type'] : FALSE;
 	}
 
 	/**

--- a/test/AggregationTest.php
+++ b/test/AggregationTest.php
@@ -192,25 +192,12 @@ class AggregationTest extends DataPerformance
 		$typeDay = Util\Aggregation::getAggregationLevelTypeValue('day');
 
 		// day: 2 rows of aggregation data, day first
-		$opt = $agg->hasDataForAggregationLevel(self::$uuid);
-		$ref = array(
-			array(
-				'level' => 'day',
-				'type' => $typeDay,
-				'count' => $this->countAggregationRows(self::$uuid, $typeDay)),
-			array(
-				'level' => 'hour',
-				'type' => $typeHour,
-				'count' => $this->countAggregationRows(self::$uuid, $typeHour)));
-		$this->assertEquals($ref, $opt);
+		$opt = $agg->hasDataForAggregationLevel(self::$uuid, $typeDay);
+		$this->assertEquals($typeDay, $opt);
 
 		// hour: 1 row of aggregation data
 		$opt = $agg->hasDataForAggregationLevel(self::$uuid, $typeHour);
-		$ref = array(array(
-			'level' => 'hour',
-			'type' => $typeHour,
-			'count' => $this->countAggregationRows(self::$uuid, $typeHour)));
-		$this->assertEquals($ref, $opt);
+		$this->assertEquals($typeHour, $opt);
 
 		// minute: no aggregation data => false
 		$typeMinute = Util\Aggregation::getAggregationLevelTypeValue('minute');

--- a/test/AggregationTest.php
+++ b/test/AggregationTest.php
@@ -205,7 +205,7 @@ class AggregationTest extends DataPerformance
 		$this->assertEquals($ref, $opt);
 
 		// hour: 1 row of aggregation data
-		$opt = $agg->hasDataForAggregationLevel(self::$uuid, 'hour');
+		$opt = $agg->hasDataForAggregationLevel(self::$uuid, $typeHour);
 		$ref = array(array(
 			'level' => 'hour',
 			'type' => $typeHour,
@@ -214,7 +214,7 @@ class AggregationTest extends DataPerformance
 
 		// minute: no aggregation data => false
 		$typeMinute = Util\Aggregation::getAggregationLevelTypeValue('minute');
-		$opt = $agg->hasDataForAggregationLevel(self::$uuid, 'minute');
+		$opt = $agg->hasDataForAggregationLevel(self::$uuid, $typeMinute);
 		$this->assertFalse($opt);
 
 		// 3 data, cannot use daily aggregates for hourly request

--- a/test/AggregationTest.php
+++ b/test/AggregationTest.php
@@ -192,7 +192,7 @@ class AggregationTest extends DataPerformance
 		$typeDay = Util\Aggregation::getAggregationLevelTypeValue('day');
 
 		// day: 2 rows of aggregation data, day first
-		$opt = $agg->getOptimalAggregationLevel(self::$uuid);
+		$opt = $agg->hasDataForAggregationLevel(self::$uuid);
 		$ref = array(
 			array(
 				'level' => 'day',
@@ -205,7 +205,7 @@ class AggregationTest extends DataPerformance
 		$this->assertEquals($ref, $opt);
 
 		// hour: 1 row of aggregation data
-		$opt = $agg->getOptimalAggregationLevel(self::$uuid, 'hour');
+		$opt = $agg->hasDataForAggregationLevel(self::$uuid, 'hour');
 		$ref = array(array(
 			'level' => 'hour',
 			'type' => $typeHour,
@@ -214,7 +214,7 @@ class AggregationTest extends DataPerformance
 
 		// minute: no aggregation data => false
 		$typeMinute = Util\Aggregation::getAggregationLevelTypeValue('minute');
-		$opt = $agg->getOptimalAggregationLevel(self::$uuid, 'minute');
+		$opt = $agg->hasDataForAggregationLevel(self::$uuid, 'minute');
 		$this->assertFalse($opt);
 
 		// 3 data, cannot use daily aggregates for hourly request


### PR DESCRIPTION
Performance was suffering when the aggregate table got larger (at least on platforms like RaspberryPI). Index utilization isn't efficient without supplying from/to to getOptimalAggregationLevel.