### PR TITLE
Use localhost instead of 127.0.0.1

### DIFF
--- a/etc/config.dist.yaml
+++ b/etc/config.dist.yaml
@@ -7,7 +7,7 @@ php:
 # http://www.doctrine-project.org/projects/doctrine-dbal/en/2.6
 db:
   driver: pdo_mysql
-  host: 127.0.0.1
+  host: localhost
   # port: 3306
   user: vz
   password: demo


### PR DESCRIPTION
If the `mysql.cnf` contains

```
[mysqld]
skip-name-resolve
```

The Doctrine scripts will error out with an unspecified error and no log entries. 
This fixes https://github.com/volkszaehler/volkszaehler.org/issues/798