### PR TITLE
Updated ensureAavailableAxis() in entity.js as per #795

### DIFF
--- a/htdocs/js/entity.js
+++ b/htdocs/js/entity.js
@@ -120,11 +120,13 @@ Entity.prototype.getUnitForMode = function () {
 };
 
 /**
- * Helper function to manage yaxes array (last entry contains template)
+ * Helper function to manage yaxes array, adds addt'l axes as required 
+ * Last yaxis defined in options.js is used as template for further axes
  */
 function ensureAavailableAxis() {
-	var length = vz.options.plot.yaxes.push($.extend({}, vz.options.plot.yaxes[1])) - 1;
-	// make sure new axis is neutral
+	var length = vz.options.plot.yaxes.length;
+	vz.options.plot.yaxes.push($.extend({}, vz.options.plot.yaxes[length-1]));
+	// make sure new axis has a neutral label
 	delete vz.options.plot.yaxes[length].axisLabel;
 	return length;
 }

--- a/htdocs/js/options.js
+++ b/htdocs/js/options.js
@@ -92,13 +92,22 @@ vz.options.plot = {
 			tickFormatter: vz.wui.tickFormatter		// show axis label
 		},
 		{
-			axisLabel: '°C', // assign el. energy to first axis- remove if not used
+			axisLabel: '°C', // assign temperature to 2nd axis- remove if not used
 			tickFormatter: vz.wui.tickFormatter		// show axis label
 		},
 		{
 			// alignTicksWithAxis: 1,
 			position: 'right',
 			tickFormatter: vz.wui.tickFormatter		// show axis label
+		},
+		{
+			/*
+			** Please note: The last axis defined in here will also be used as a 
+			** template to clone further axes as needed. All settings (except the 
+			** axis label) will replicate into those additional axes.
+			*/
+			position: 'left',
+			tickFormatter: vz.wui.tickFormatter             // show axis label
 		}
 	],
 	selection: { mode: 'x' },

--- a/htdocs/js/options.js
+++ b/htdocs/js/options.js
@@ -96,18 +96,14 @@ vz.options.plot = {
 			tickFormatter: vz.wui.tickFormatter		// show axis label
 		},
 		{
-			// alignTicksWithAxis: 1,
-			position: 'right',
-			tickFormatter: vz.wui.tickFormatter		// show axis label
-		},
-		{
 			/*
 			** Please note: The last axis defined in here will also be used as a 
 			** template to clone further axes as needed. All settings (except the 
 			** axis label) will replicate into those additional axes.
 			*/
-			position: 'left',
-			tickFormatter: vz.wui.tickFormatter             // show axis label
+			position: 'right',
+			// alignTicksWithAxis: 1,
+			tickFormatter: vz.wui.tickFormatter		// show axis label
 		}
 	],
 	selection: { mode: 'x' },


### PR DESCRIPTION
The `ensureAavailableAxis()` function in _entity.js_ creates additional y-axes on the fly, if no (more) matching axes are defined as per `vz.options.plot.yaxes` in _options.js_. The current behaviour is to clone the 2nd axis defined in options.js, which can lead to issues like the one described in #795.

This PR's approach is to use the last defined axis instead, and let the user know about this per comment in options.js. See the conversation in #795 for details.

The changes have been thoroughly tested and debugged. In fact, the 1st time `ensureAavailableAxis()` is invoked it uses the last defined axis as per options.js as a template, replicates it and adds it to the array. In the next run it would use that last automatically created axis as template, and so on.