### PR TITLE
Add pdo_pgsql to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ EXPOSE 8080
 EXPOSE 8082
 EXPOSE 5582
 
-RUN docker-php-ext-install pcntl pdo_mysql
+RUN apk add postgresql-dev
+RUN docker-php-ext-install pcntl pdo_mysql pdo_pgsql
 
 COPY --from=builder /vz /vz
 COPY --from=builder /vz/etc/config.dist.yaml /vz/etc/config.yaml


### PR DESCRIPTION
Updated my docker container today to find the postgresql driver missing. Not sure if that's by design and people should just build their own container for specialized setups (feel free to close this PR in that kind of case) or an oversight.