### PR TITLE
Use composite primary keys

### DIFF
--- a/lib/Model/Aggregate.php
+++ b/lib/Model/Aggregate.php
@@ -23,13 +23,12 @@
 
 namespace Volkszaehler\Model;
 
-use Doctrine\Common\Collections\ArrayCollection;
-use Volkszaehler\Model;
-
 /**
  * Aggregate materialized view entity
  *
  * @author Andreas Goetz <cpuidle@gmx.de>
+ *
+ * @todo change index name to something more meaningful like aggregate_channel_type_ts_idx
  *
  * @Entity
  * @Table(
@@ -41,14 +40,6 @@ class Aggregate
 {
 	/**
 	 * @Id
-	 * @Column(type="integer", nullable=false)
-	 * @GeneratedValue(strategy="AUTO")
-	 *
-	 * @todo wait until DDC-117 is fixed (PKs on FKs)
-	 */
-	protected $id;
-
-	/**
 	 * @ManyToOne(targetEntity="Channel", inversedBy="aggregate")
 	 * @JoinColumn(name="channel_id", referencedColumnName="id", nullable=false)
 	 *
@@ -59,6 +50,7 @@ class Aggregate
 	/**
 	 * Aggregation type
 	 *
+	 * @Id
 	 * @Column(type="smallint", nullable=false)
 	 */
 	protected $type;
@@ -66,6 +58,7 @@ class Aggregate
 	/**
 	 * Ending timestamp of period in ms since 1970
 	 *
+	 * @Id
 	 * @Column(type="bigint", nullable=false)
 	 */
 	protected $timestamp;
@@ -82,7 +75,7 @@ class Aggregate
 	 */
 	protected $count;
 
-	public function __construct(Model\Channel $channel, $type, $timestamp, $value, $count)
+	public function __construct(Channel $channel, $type, $timestamp, $value, $count)
 	{
 		$this->channel = $channel;
 		$this->type = $type;

--- a/lib/Model/Aggregate.php
+++ b/lib/Model/Aggregate.php
@@ -36,7 +36,7 @@ class Aggregate
 	/**
 	 * @Id
 	 * @ManyToOne(targetEntity="Channel", inversedBy="aggregate")
-	 * @JoinColumn(name="channel_id", referencedColumnName="id", nullable=false)
+	 * @JoinColumn(name="channel_id", referencedColumnName="id")
 	 *
 	 * @todo implement inverse side (Channel->aggregate)
 	 */
@@ -46,7 +46,7 @@ class Aggregate
 	 * Aggregation type
 	 *
 	 * @Id
-	 * @Column(type="smallint", nullable=false)
+	 * @Column(type="smallint")
 	 */
 	protected $type;
 
@@ -54,7 +54,7 @@ class Aggregate
 	 * Ending timestamp of period in ms since 1970
 	 *
 	 * @Id
-	 * @Column(type="bigint", nullable=false)
+	 * @Column(type="bigint")
 	 */
 	protected $timestamp;
 

--- a/lib/Model/Aggregate.php
+++ b/lib/Model/Aggregate.php
@@ -31,10 +31,7 @@ namespace Volkszaehler\Model;
  * @todo change index name to something more meaningful like aggregate_channel_type_ts_idx
  *
  * @Entity
- * @Table(
- * 	name="aggregate",
- *	uniqueConstraints={@UniqueConstraint(name="aggregate_unique", columns={"channel_id", "type", "timestamp"})}
- * )
+ * @Table(name="aggregate")
  */
 class Aggregate
 {

--- a/lib/Model/Aggregate.php
+++ b/lib/Model/Aggregate.php
@@ -28,8 +28,6 @@ namespace Volkszaehler\Model;
  *
  * @author Andreas Goetz <cpuidle@gmx.de>
  *
- * @todo change index name to something more meaningful like aggregate_channel_type_ts_idx
- *
  * @Entity
  * @Table(name="aggregate")
  */

--- a/lib/Model/Aggregator.php
+++ b/lib/Model/Aggregator.php
@@ -59,7 +59,7 @@ class Aggregator extends Entity
 	 *
 	 * @param Entity $child
 	 * @todo check if the entity is already member of the group
-	 * @todo add bidrectional association
+	 * @todo add bidirectional association
 	 */
 	public function addChild(Entity $child)
 	{
@@ -78,7 +78,7 @@ class Aggregator extends Entity
 	 * Checks if aggregator contains given entity
 	 *
 	 * @param Entity $entity
-	 * @param boolean $recursive should we search recursivly?
+	 * @param boolean $recursive should we search recursively?
 	 */
 	protected function contains(Entity $entity, $recursive = FALSE)
 	{

--- a/lib/Model/Channel.php
+++ b/lib/Model/Channel.php
@@ -62,7 +62,7 @@ class Channel extends Entity
 	/**
 	 * Add a new data to the database
 	 */
-	public function addData(\Volkszaehler\Model\Data $data)
+	public function addData(Data $data)
 	{
 		$this->data->add($data);
 	}

--- a/lib/Model/Data.php
+++ b/lib/Model/Data.php
@@ -37,13 +37,13 @@ class Data
 	/**
 	 * @Id
 	 * @ManyToOne(targetEntity="Channel", inversedBy="data")
-	 * @JoinColumn(name="channel_id", referencedColumnName="id", nullable=false)
+	 * @JoinColumn(name="channel_id", referencedColumnName="id")
 	 */
 	protected $channel;
 
 	/**
 	 * @Id
-	 * @Column(type="bigint", nullable=false)
+	 * @Column(type="bigint")
 	 */
 	protected $timestamp;
 

--- a/lib/Model/Data.php
+++ b/lib/Model/Data.php
@@ -23,13 +23,13 @@
 
 namespace Volkszaehler\Model;
 
-use Doctrine\Common\Collections\ArrayCollection;
-use Volkszaehler\Model;
-
 /**
  * Data entity
  *
  * @author Steffen Vogel <info@steffenvogel.de>
+ * @author Andreas Goetz <cpuidle@gmx.de>
+ *
+ * @todo change index name to something more meaningful like data_channel_ts_idx
  *
  * @Entity
  * @Table(
@@ -41,16 +41,13 @@ class Data
 {
 	/**
 	 * @Id
-	 * @Column(type="integer", nullable=false)
-	 * @GeneratedValue(strategy="IDENTITY")
-	 *
-	 * @todo wait until DDC-117 is fixed (PKs on FKs)
+	 * @ManyToOne(targetEntity="Channel", inversedBy="data")
+	 * @JoinColumn(name="channel_id", referencedColumnName="id", nullable=false)
 	 */
-	protected $id;
+	protected $channel;
 
 	/**
-	 * Ending timestamp of period in ms since 1970
-	 *
+	 * @Id
 	 * @Column(type="bigint", nullable=false)
 	 */
 	protected $timestamp;
@@ -60,13 +57,7 @@ class Data
 	 */
 	protected $value;
 
-	/**
-	 * @ManyToOne(targetEntity="Channel", inversedBy="data")
-	 * @JoinColumn(name="channel_id", referencedColumnName="id", nullable=false)
-	 */
-	protected $channel;
-
-	public function __construct(Model\Channel $channel, $timestamp, $value)
+	public function __construct(Channel $channel, $timestamp, $value)
 	{
 		$this->channel = $channel;
 

--- a/lib/Model/Data.php
+++ b/lib/Model/Data.php
@@ -32,10 +32,7 @@ namespace Volkszaehler\Model;
  * @todo change index name to something more meaningful like data_channel_ts_idx
  *
  * @Entity
- * @Table(
- * 	name="data",
- *	uniqueConstraints={@UniqueConstraint(name="data_unique", columns={"channel_id", "timestamp"})}
- * )
+ * @Table(name="data")
  */
 class Data
 {

--- a/lib/Model/Data.php
+++ b/lib/Model/Data.php
@@ -29,8 +29,6 @@ namespace Volkszaehler\Model;
  * @author Steffen Vogel <info@steffenvogel.de>
  * @author Andreas Goetz <cpuidle@gmx.de>
  *
- * @todo change index name to something more meaningful like data_channel_ts_idx
- *
  * @Entity
  * @Table(name="data")
  */

--- a/lib/Model/Entity.php
+++ b/lib/Model/Entity.php
@@ -47,15 +47,19 @@ abstract class Entity
 {
 	/**
 	 * @Id
-	 * @Column(type="integer", nullable=false)
+	 * @Column(type="integer")
 	 * @GeneratedValue(strategy="AUTO")
 	 */
 	protected $id;
 
-	/** @Column(type="string", length=36, nullable=false, unique=true) */
+	/**
+	 * @Column(type="string", length=36, nullable=false, unique=true)
+	 */
 	protected $uuid;
 
-	/** @Column(type="string", nullable=false) */
+	/**
+	 * @Column(type="string", nullable=false)
+	 */
 	protected $type;
 
 	/**

--- a/lib/Model/Property.php
+++ b/lib/Model/Property.php
@@ -24,7 +24,6 @@
 namespace Volkszaehler\Model;
 
 use Volkszaehler\Definition;
-use Volkszaehler\Model;
 
 /**
  * Property entity
@@ -44,14 +43,13 @@ class Property
 {
 	/**
 	 * @Id
-	 * @Column(type="integer", nullable=false)
-	 * @GeneratedValue(strategy="AUTO")
-	 *
-	 * @todo wait until DDC-117 is fixed (PKs on FKs)
+	 * @ManyToOne(targetEntity="Entity", inversedBy="properties")
+	 * @JoinColumn(name="entity_id", nullable=false)
 	 */
-	protected $id;
+	protected $entity;
 
 	/**
+	 * @Id
 	 * @Column(name="pkey", type="string", nullable=false)
 	 * HINT: column name "key" is reserved by mysql
 	 */
@@ -63,18 +61,12 @@ class Property
 	protected $value;
 
 	/**
-	 * @ManyToOne(targetEntity="Entity", inversedBy="properties")
-	 * @JoinColumn(name="entity_id", nullable=false)
-	 */
-	protected $entity;
-
-	/**
 	 * Constructor
 	 *
 	 * @param string $key
 	 * @param string $value
 	 */
-	public function __construct(Model\Entity $entity, $key, $value)
+	public function __construct(Entity $entity, $key, $value)
 	{
 		$this->entity = $entity;
 		$this->key = $key;

--- a/lib/Model/Property.php
+++ b/lib/Model/Property.php
@@ -31,12 +31,7 @@ use Volkszaehler\Definition;
  * @author Steffen Vogel <info@steffenvogel.de>
  *
  * @Entity
- * @Table(
- * 		name="properties",
- * 		uniqueConstraints={
- * 			@UniqueConstraint(name="property_unique", columns={"entity_id", "pkey"})
- * 		}
- * )
+ * @Table(name="properties")
  * @HasLifecycleCallbacks
  */
 class Property

--- a/lib/Model/Property.php
+++ b/lib/Model/Property.php
@@ -39,13 +39,13 @@ class Property
 	/**
 	 * @Id
 	 * @ManyToOne(targetEntity="Entity", inversedBy="properties")
-	 * @JoinColumn(name="entity_id", nullable=false)
+	 * @JoinColumn(name="entity_id")
 	 */
 	protected $entity;
 
 	/**
 	 * @Id
-	 * @Column(name="pkey", type="string", nullable=false)
+	 * @Column(name="pkey", type="string")
 	 * HINT: column name "key" is reserved by mysql
 	 */
 	protected $key;


### PR DESCRIPTION
This PR replaces the unnecessary surrogate primary keys with composite primary keys as enabled by Doctrine DDC-117.

It was observed during maintenance of the demo database (~1bn records) that the old integer PK would sooner or later run out of space.

Builds on #853.
