### PR TITLE
Add mysqli driver to docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ EXPOSE 8082
 EXPOSE 5582
 
 RUN apk add postgresql-dev
-RUN docker-php-ext-install pcntl pdo_mysql pdo_pgsql
+RUN docker-php-ext-install pcntl pdo_mysql pdo_pgsql mysqli
 
 COPY --from=builder /vz /vz
 COPY --from=builder /vz/etc/config.dist.yaml /vz/etc/config.yaml


### PR DESCRIPTION
I use a a maria db server that is requiring ssl secured connection. I was not able to configure this with the pdo_mysql driver, so I use the mysqli driver. I think adding the driver to the docker image may help other that want to use docker and for some reason the mysqli database driver.