### PR TITLE
[Docker] Remove postgresql-dev after building the driver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,9 @@ EXPOSE 8080
 EXPOSE 8082
 EXPOSE 5582
 
-RUN apk add postgresql-dev
-RUN docker-php-ext-install pcntl pdo_mysql pdo_pgsql mysqli
+RUN apk add --no-cache postgresql-libs postgresql-dev \
+    && docker-php-ext-install pcntl pdo_mysql pdo_pgsql mysqli \
+    && apk del postgresql-dev
 
 COPY --from=builder /vz /vz
 COPY --from=builder /vz/etc/config.dist.yaml /vz/etc/config.yaml


### PR DESCRIPTION
This reduces the image size in my tests from 426 MB to 110 MB
the steps are taken from https://github.com/docker-library/php/issues/221#issuecomment-385775216

@SharkyRawr You added the postgresql in #824. I have no postgresql server at my hand to test. Can you test if this is working with your postgresql?