### PR TITLE
Remove react/http dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
         "symfony/routing": "^4.4|^5.0",
         "symfony/yaml": "^4.4|^5.0",
         "cboden/ratchet": "^0.4",
-        "react/http": "^1.0",
         "ringcentral/psr7": "^1.2",
         "php-pm/php-pm": "^2.0",
         "php-pm/httpkernel-adapter": "^2.0",


### PR DESCRIPTION
react/http is a depency of php-pm/php-pm and stil will be installed
react/http 1.4 and php-pm/php-pm 2.2.2 have problems, see https://github.com/php-pm/php-pm/issues/538
Without this react/http 1.4 and php-pm 2.2.1 will be insatlled and result into that issue

Resolves #866