### PR TITLE
Fix crash when debugging SQL query without parameters

### DIFF
--- a/lib/Util/Debug.php
+++ b/lib/Util/Debug.php
@@ -155,7 +155,7 @@ class Debug {
 	 * @author Andreas Goetz <cpuidle@gmx.de>
 	 */
 	public static function getParametrizedQuery($sql, $sqlParameters) {
-		while (count($sqlParameters)) {
+		while (count((array) $sqlParameters)) {
 			$sql = preg_replace('/\?/', self::formatSQLParameter(array_shift($sqlParameters)), $sql, 1);
 		}
 		if (php_sapi_name() === 'cli' && class_exists('\SqlFormatter')) {


### PR DESCRIPTION
When one edits channel data, a PATCH request is sent to the server.
An SQL query "START TRANSACTION" is run which has no parameters.

When debugging is enabled, that query shall be pretty-printed
but fails because the $sqlParameters parameter is NULL:

```
"exception": {
    "message": "Warning: count(): Parameter must be an array or an object that implements Countable",
    "type": "ErrorException",
    "code": 0,
    "file": "volkszaehler.org\/lib\/Util\/Debug.php",
    "line": 158,
    "backtrace": [
        {
            "file": "volkszaehler.org\/lib\/View\/JSON.php",
            "line": 324,
            "function": "getParametrizedQuery",
            "class": "Volkszaehler\\Util\\Debug"
        },
        ...
    ]
}
```