### PR TITLE
Display line breaks in channel description

### DIFF
--- a/htdocs/css/style.css
+++ b/htdocs/css/style.css
@@ -31,6 +31,9 @@ tr.stale td.consumption, tr.stale td.cost, tr.stale td.total {
 table.properties tr:not(:first-child) {
 	border-top: 1px solid #ddd;
 }
+table.properties td.key {
+	vertical-align: top;
+}
 
 td input:not([type=image]):not([type=checkbox]) {
 	width: 100%;

--- a/htdocs/js/entity.js
+++ b/htdocs/js/entity.js
@@ -623,6 +623,10 @@ Entity.prototype.getDOMDetails = function (edit) {
 						value = Number(value * 100).toFixed(2) + prefix + vz.wui.formatConsumptionUnit(this.getUnit());
 						break;
 
+					case 'description':
+						value = (value + '').replace(/([^>\r\n]?)(\r\n|\n\r|\r|\n)/g, '$1<br/>$2');
+						break;
+
 					case 'resolution':
 						prefix = (this.getUnit() && this.definition.scale == 1000) ? 'k' : ''; // per Wh or kWh
 						value += '/' + prefix + vz.wui.formatConsumptionUnit(this.getUnit());

--- a/htdocs/js/wui.js
+++ b/htdocs/js/wui.js
@@ -374,7 +374,7 @@ vz.wui.dialogs.addProperties = function(container, proplist, className, entity) 
 			if (def == propdef.name) {
 				var cntrl = null;
 				var row = $('<tr>').append(
-					$('<td>').text(propdef.translation[vz.options.language])
+					$('<td class="key">').text(propdef.translation[vz.options.language])
 				);
 
 				switch (propdef.type) {


### PR DESCRIPTION
The description of a channel is a string and may contain newlines.
This patch replaces them with <br> tags so that they are properly
visible when viewing the channel details.

(Description is hidden by default and needs to be enabled in
htdocs/js/options.js, hiddenProperties)

Resolves: https://github.com/volkszaehler/volkszaehler.org/issues/713