### PR TITLE
Optional deactivate uuid from url

### DIFF
--- a/htdocs/js/functions.js
+++ b/htdocs/js/functions.js
@@ -179,6 +179,7 @@ vz.parseUrlParams = function() {
 	var vars = $.getUrlParams();
 	var entities = [];
 	var save = false;
+	var active = null;
 
 	for (var key in vars) {
 		if (vars.hasOwnProperty(key)) {
@@ -189,6 +190,10 @@ vz.parseUrlParams = function() {
 
 				case 'save': // save new uuids in cookie
 					save = vars[key];
+					break;
+
+				case 'active': // define active/deactive state for uuid from url. Set to deactive when set to FALSE, F, NO or 0 (case insensitive)
+					active = !/^(?:f(?:alse)?|no?|0+)$/i.test(vars[key]);
 					break;
 
 				case 'from':
@@ -241,7 +246,8 @@ vz.parseUrlParams = function() {
 		var entity = new Entity({
 			uuid: uuid,
 			middleware: middleware,
-			cookie: save
+			cookie: save,
+			active: active
 		});
 
 		// avoid double entries


### PR DESCRIPTION
By default a uuid added by url is activated. When the uuid is a group this might me unwanted.
The parameter active defines if the uuid is active or not. 
The default value is not changed. Deactivated when set active to FALSE, F, NO, or 0  (case insensitive)
Example:
https://demo.volkszaehler.org/?uuid=6836dd20-00d5-11e0-bab1-856ed5f959ae&active=0