### PR TITLE
Fix E_NOTICE in virtual channel: access array offset on null

### DIFF
--- a/lib/Interpreter/Virtual/TimestampGenerator.php
+++ b/lib/Interpreter/Virtual/TimestampGenerator.php
@@ -45,8 +45,8 @@ class TimestampGenerator implements \IteratorAggregate {
 
 		// get minimum from timestamp
 		$from = array_reduce($this->iterators, function($carry, $iterator) {
-			// if (!$iterator->valid())
-			// 	return $carry;
+			if (!$iterator->valid())
+				return $carry;
 			$current = $iterator->current();
 			if ($carry === null || $current < $carry)
 				return $current;


### PR DESCRIPTION
Sometimes the virtual channel fails with an ErrorException
> Notice: Trying to access array offset on value of type null

This depends on the "from" and "to" range.
Some ranges don't exhibit this problem, but most do.

This code had been added in the initial implementation of virtual
channels in https://github.com/volkszaehler/volkszaehler.org/pull/729
but was deactivated. "git log" does not indicate why that is so.

Example URL with that error:
http://strom/api/data/fa7e3070-af2b-11ec-945d-874270cd36b6.json?unique=1648649200587&from=1648635064050&to=1648636657524&tuples=496

Stack trace:
> ErrorException:
> Notice: Trying to access array offset on value of type null
>
>  at lib/Interpreter/Virtual/TimestampIterator.php:31
>  at Volkszaehler\Interpreter\Virtual\TimestampIterator->current()
>     (lib/Interpreter/Virtual/TimestampGenerator.php:51)
>  at Volkszaehler\Interpreter\Virtual\TimestampGenerator->Volkszaehler\Interpreter\Virtual\{closure}()
>  at array_reduce()
>     (lib/Interpreter/Virtual/TimestampGenerator.php:55)
>  at Volkszaehler\Interpreter\Virtual\TimestampGenerator->getIterator()
>     (lib/Interpreter/VirtualInterpreter.php:214)