### PR TITLE
update action to latest versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
         with:
           fetch-depth: 0
 
@@ -40,7 +40,7 @@ jobs:
           ini-values: "disable_functions="
 
       - name: "Cache dependencies installed with composer"
-        uses: "actions/cache@v2"
+        uses: "actions/cache@v3"
         with:
           path: "~/.composer/cache"
           key: "php-${{ matrix.php-version }}-composer-locked-${{ hashFiles('composer.lock') }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: volkszaehler/volkszaehler
           tags: |


### PR DESCRIPTION
reason for new major version is the requirement of node 16 as runtime (which github action have)

https://github.com/actions/checkout/releases/tag/v3.0.0
https://github.com/actions/cache/releases/tag/v3.0.0
https://github.com/docker/metadata-action/releases/tag/v4.0.0