### PR TITLE
vzcompress2: strftime() deprecated, use date()

### DIFF
--- a/bin/vzcompress2
+++ b/bin/vzcompress2
@@ -67,7 +67,7 @@ class VZcompress2 {
 	private $channels;
 
 	private $purgecounter = 0;
-	private $timestr = '%x %X';
+	private $timestr = 'Y-m-d H:i:s';
 
 	public function __construct($config = array()) {
 		$this->config = array_replace(
@@ -155,7 +155,7 @@ class VZcompress2 {
 	 * Output functions
 	 */
 	private function strftime($time = null) {
-		return strftime($this->timestr, $time ?: time());
+		return date($this->timestr, $time);
 	}
 
 	private function out($str, $delim = "\n") {


### PR DESCRIPTION
strftime() is deprecated since php 8.1 and will be removed in php 9.0. For simplicity, instead of the locale dependent date and time format, we now use the ISO format (YYYY-MM-DD HH:MM:SS). vzcompress2 uses it merely for logging, so this change should be safe.