### PR TITLE
added return types to methods of classes derived from IteratorIterator

### DIFF
--- a/lib/Interpreter/Virtual/DelayedIterator.php
+++ b/lib/Interpreter/Virtual/DelayedIterator.php
@@ -40,12 +40,12 @@ class DelayedIterator extends \IteratorIterator
 	 * Iterator
 	 */
 
-	public function rewind() {
+	public function rewind() : void {
 		parent::rewind();
 		$this->next();
 	}
 
-	public function next() {
+	public function next() : void {
 		$this->valid = parent::valid();
 		if ($this->valid) {
 			$this->key = parent::key();
@@ -54,15 +54,15 @@ class DelayedIterator extends \IteratorIterator
 		}
 	}
 
-	public function valid() {
+	public function valid() : bool {
 		return $this->valid;
 	}
 
-	public function key() {
+	public function key() : mixed {
 		return $this->key;
 	}
 
-	public function current() {
+	public function current() : mixed {
 		return $this->current;
 	}
 }

--- a/lib/Interpreter/Virtual/GroupedTimestampIterator.php
+++ b/lib/Interpreter/Virtual/GroupedTimestampIterator.php
@@ -64,7 +64,7 @@ class GroupedTimestampIterator extends \IteratorIterator {
 	 * Iterator
 	 */
 
-	public function rewind() {
+	public function rewind() : void {
 		parent::rewind();
 
 		if ($this->valid()) {
@@ -79,7 +79,7 @@ class GroupedTimestampIterator extends \IteratorIterator {
 		}
 	}
 
-	public function next() {
+	public function next() : void {
 		/** @var DelayedIterator */
 		$inner = $this->getInnerIterator();
 

--- a/lib/Interpreter/Virtual/LookbackIterator.php
+++ b/lib/Interpreter/Virtual/LookbackIterator.php
@@ -35,12 +35,12 @@ class LookbackIterator extends \IteratorIterator {
 	 * IteratorIterator
 	 */
 
-	function rewind() {
+	function rewind() : void {
 		$this->previous = array(0, 0, 0);
 		parent::rewind();
 	}
 
-	function next() {
+	function next() : void {
 		$this->previous = $this->current();
 		parent::next();
 	}

--- a/lib/Interpreter/Virtual/TimestampIterator.php
+++ b/lib/Interpreter/Virtual/TimestampIterator.php
@@ -27,7 +27,7 @@ namespace Volkszaehler\Interpreter\Virtual;
  * Helper iterator that extracts timestamp from tuple
  */
 class TimestampIterator extends \IteratorIterator {
-	function current() {
+	function current() : mixed {
 		return parent::current()[0];
 	}
 }


### PR DESCRIPTION
since php 8.1, derived classes must have the same (or are more specific) return type than their base class. a missing return type is considered a mismatch. see https://php.watch/versions/8.1/internal-method-return-types

return types are supported since php 7.1, so this should not break anything.