### PR TITLE
push the arm platforms to docker hub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,6 +47,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
+          platforms: linux/amd64,linux/arm64,linux/arm/v6
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
with #947 from @janknieling the docker build for arm was done

But the only the amd64 images are pushed to the docker hub (see https://hub.docker.com/layers/volkszaehler/volkszaehler/sha-7770dc8/images/sha256-0d3c9a7ecec1014724228c6d959a1f5d169126860a6ab9d1467443a00e6765c0?context=explore)

This PR pushes additional the arm v6 and arm64 to the docker hub