### PR TITLE
bump github actions to new versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
         with:
           fetch-depth: 0
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,22 +11,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: 'arm64,arm,amd64'
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: volkszaehler/volkszaehler
           tags: |
@@ -34,7 +34,7 @@ jobs:
             type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
 
       - name: Build for test
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           load: true
           tags: volkszaehler/volkszaehler
@@ -44,7 +44,7 @@ jobs:
         run: ./misc/dockertest/test-docker.sh
 
       - name: Push image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
main change is the node 20 runtime and with the hosted agent this is no problem
https://github.com/actions/checkout/releases/tag/v4.0.0
https://github.com/docker/setup-qemu-action/releases/tag/v3.0.0
https://github.com/docker/setup-buildx-action/releases/tag/v3.0.0
https://github.com/docker/login-action/releases/tag/v3.0.0
https://github.com/docker/metadata-action/releases/tag/v5.0.0